### PR TITLE
Keep root path in canonical

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -775,6 +775,7 @@ namespace detail
   path canonical(const path& p, const path& base, system::error_code* ec)
   {
     path source (p.is_absolute() ? p : absolute(p, base));
+    path root_path (source.root_path());
     path result;
 
     system::error_code local_ec;
@@ -809,7 +810,8 @@ namespace detail
           continue;
         if (*itr == dot_dot_path)
         {
-          result.remove_filename();
+          if (result != root_path)
+            result.remove_filename();
           continue;
         }
 

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -1411,6 +1411,7 @@ namespace
     BOOST_TEST_EQ(fs::canonical(fs::current_path()), fs::current_path());
     BOOST_TEST_EQ(fs::canonical(fs::current_path(), ""), fs::current_path());
     BOOST_TEST_EQ(fs::canonical(fs::current_path(), "no-such-file"), fs::current_path());
+    BOOST_TEST_EQ(fs::canonical(".." / fs::current_path(), fs::current_path().root_path()), fs::current_path());
 
     BOOST_TEST_EQ(fs::canonical("."), fs::current_path());
     BOOST_TEST_EQ(fs::canonical(".."), fs::current_path().parent_path());


### PR DESCRIPTION
[The assertion](https://github.com/boostorg/filesystem/blob/develop/src/operations.cpp#L850) fails if you call `canonical("../some-directory", "/")`. This is because the root path is removed in the loop if the current segment equals to `..` although the current `result` only contains the root path.
I think one would expect `/some-directory` as the result.

I don't know if there is a more efficient/elegant solution. Let me know if there is one. :)
