### PR TITLE
Fix trac ticket 5403

### DIFF
--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -823,9 +823,11 @@ namespace filesystem
             m_stack.push(directory_iterator(m_stack.top()->path()));
           else
           {
-            m_stack.push(directory_iterator(m_stack.top()->path(), *ec));
+            directory_iterator next = directory_iterator(m_stack.top()->path(), *ec);
             if (*ec)
               return;
+            else
+              m_stack.push(next);
           }
           if (m_stack.top() != directory_iterator())
           {


### PR DESCRIPTION
This resolves a bug where the directory_iterator at the top of the stack
is invalid (ie. an end iterator) if an error occurs. So, you cannot
dereference it, and you cannot use any other method (e.g. no_push) on
it, otherwise std::abort will be called.

Avoid pushing an end iterator onto the directory stack.

[1] https://svn.boost.org/trac/boost/ticket/5403
[2] https://svn.boost.org/trac/boost/ticket/6821#comment:5
