### PR TITLE
haiku: don't crash because of unsupported locale in libstdc++

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -36,7 +36,7 @@
 # include "windows_file_codecvt.hpp"
 # include <windows.h>
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
- || defined(__FreeBSD__) || defined(__OPEN_BSD__)
+ || defined(__FreeBSD__) || defined(__OPEN_BSD__) || defined(__HAIKU__)
 # include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 #endif
 
@@ -831,7 +831,7 @@ namespace
     std::locale global_loc = std::locale();
     return std::locale(global_loc, new windows_file_codecvt);
 # elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
-  || defined(__FreeBSD__) || defined(__OpenBSD__)
+  || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
     // "All BSD system functions expect their string parameters to be in UTF-8 encoding
     // and nothing else." See
     // http://developer.apple.com/mac/library/documentation/MacOSX/Conceptual/BPInternational/Articles/FileEncodings.html


### PR DESCRIPTION
See https://svn.boost.org/trac/boost/ticket/4688
We do the same as on Mac OS X and assume the filesystem uses utf-8.

Signed-off-by: Jessica Hamilton <jessica.l.hamilton@gmail.com>