### PR TITLE
Changed operations to allow to be compiled on VxWorks

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -82,9 +82,7 @@ using std::wstring;
 #     include <sys/vfs.h>
 #     endif
 
-#     if defined(__VXWORKS__)
-#     include <sys/stat.h>
-#     else
+#     if !defined(__VXWORKS__)
 #     include <sys/mount.h>
 #     endif
 


### PR DESCRIPTION
While on Linux system stat_vfs() and fstat_vfs() are used to gain information about a mounted volume, VxWorks uses dirLib routines statfs() and fstatfs(), that are POSIX-compliant routines to gain information about a file system. 
This change includes the proper header for VxWorks to to allow the proper access for those functions.
