### PR TITLE
Removing inconsistency between the source code and its tutorial.

### DIFF
--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -565,27 +565,11 @@ boost::filesystem::status: The device is not ready: &quot;e:\&quot;</pre>
   </tr>
 </table>
 
-    <p>The key difference between <code>tut3.cpp</code> and <code>tut4.cpp</code> is 
-    what happens in the directory iteration loop. We changed:</p>
-    <blockquote>
-      <pre>cout &lt;&lt; &quot; &quot; &lt;&lt; *it &lt;&lt; '\n';   // *it returns a <a href="reference.html#Class-directory_entry">directory_entry</a>,</pre>
-    </blockquote>
-    <p>to:</p>
-    <blockquote>
-      <pre>cout &lt;&lt; &quot;   &quot; &lt;&lt; it-&gt;filename() &lt;&lt; '\n';</pre>
-    </blockquote>
-    <p><code><a href="reference.html#directory_entry-observers">path()</a></code> 
-    is a <code>directory_entry</code> observer function. <code>
-    <a href="reference.html#path-filename">filename()</a></code> is one of 
+    <p><code><a href="reference.html#path-filename">filename()</a></code> is one of 
     several path decomposition functions. It extracts the filename portion (<code>&quot;index.html&quot;</code>) 
     from a path (<code>&quot;/home/beman/boost/trunk/index.html&quot;</code>). These decomposition functions are 
     more fully explored in the <a href="#Class path-iterators-etc">Path iterators, observers, 
     composition, decomposition and query</a> portion of this tutorial.</p>
-    <p>The above was written as two lines of code for clarity. It could have 
-    been written more concisely as:</p>
-    <blockquote>
-      <pre>v.push_back(it-&gt;path().filename()); // we only care about the filename</pre>
-    </blockquote>
     <p>Here is the output from a test of <code><a href="../example/tut4.cpp">tut4.cpp</a></code>:</p>
 
   <table align="center" border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse" bordercolor="#111111" bgcolor="#D7EEFF" width="90%">

--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -542,7 +542,7 @@ boost::filesystem::status: The device is not ready: &quot;e:\&quot;</pre>
   
         for (vec::const_iterator it (v.begin()); it != v.end(); ++it)
         {
-          cout &lt;&lt; &quot;   &quot; &lt;&lt; *it &lt;&lt; '\n';
+          cout &lt;&lt; &quot;   &quot; &lt;&lt; it-&gt;filename() &lt;&lt; '\n';
         }
       }
 
@@ -572,8 +572,7 @@ boost::filesystem::status: The device is not ready: &quot;e:\&quot;</pre>
     </blockquote>
     <p>to:</p>
     <blockquote>
-      <pre>path fn = it-&gt;path().filename();   // extract the filename from the path
-v.push_back(fn);                   // push into vector for later sorting</pre>
+      <pre>cout &lt;&lt; &quot;   &quot; &lt;&lt; it-&gt;filename() &lt;&lt; '\n';</pre>
     </blockquote>
     <p><code><a href="reference.html#directory_entry-observers">path()</a></code> 
     is a <code>directory_entry</code> observer function. <code>

--- a/example/tut4.cpp
+++ b/example/tut4.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
 
         for (vec::const_iterator it(v.begin()), it_end(v.end()); it != it_end; ++it)
         {
-          cout << "   " << *it << '\n';
+          cout << "   " << it->filename() << '\n';
         }
       }
       else


### PR DESCRIPTION
There is an inconsistency between the tutorial page of the Filesystem library and one of its example source code. Refer to [this](https://github.com/jaggi1234/filesystem/commit/066f96fa62cca4f21ffdfba49f3e0db2d1f459c2) for info.
