### PR TITLE
Introduced VxWorks Simulator root

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -82,9 +82,7 @@ using std::wstring;
 #     include <sys/vfs.h>
 #     endif
 
-#     if defined(__VXWORKS__)
-#     include <sys/stat.h>
-#     else
+#     if !defined(__VXWORKS__)
 #     include <sys/mount.h>
 #     endif
 

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -71,7 +71,7 @@ using std::wstring;
 
 #   include <sys/types.h>
 #   include <sys/stat.h>
-#   if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__ANDROID__)
+#   if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__ANDROID__) && !defined(__VXWORKS__)
 #     include <sys/statvfs.h>
 #     define BOOST_STATVFS statvfs
 #     define BOOST_STATVFS_F_FRSIZE vfs.f_frsize
@@ -81,7 +81,13 @@ using std::wstring;
 #     elif defined(__ANDROID__)
 #     include <sys/vfs.h>
 #     endif
+
+#     if defined(__VXWORKS__)
+#     include <sys/stat.h>
+#     else
 #     include <sys/mount.h>
+#     endif
+
 #     define BOOST_STATVFS statfs
 #     define BOOST_STATVFS_F_FRSIZE static_cast<boost::uintmax_t>(vfs.f_bsize)
 #   endif

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -530,6 +530,12 @@ namespace
       && is_separator(path[2])) return 2;
 #   endif
 
+#   ifdef _VX_CPU
+    // case "host:" - VxWorks simulator
+    if (size > 5
+        && path[4] == colon) return 5;
+#   endif
+
     // case "//"
     if (size == 2
       && is_separator(path[0])


### PR DESCRIPTION
Introduced the root path for the VxWorks simulator.
It the "host:" is not handled, this can cause infinite recursive call on
VxWorks simulator when usinf the canonical function