### PR TITLE
Introduced VxWorks Simulator root and corrected canonical for VxWorks

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -397,6 +397,7 @@ namespace
 //--------------------------------------------------------------------------------------//
 
   const char dot = '.';
+  const char* preferred_separator_string = "/";
 
   bool not_found_error(int errval)
   {
@@ -485,6 +486,7 @@ namespace
   const std::size_t buf_size=128;
 
   const wchar_t dot = L'.';
+  const wchar_t* preferred_separator_string = L"\\";
 
   bool not_found_error(int errval)
   {
@@ -829,7 +831,15 @@ namespace detail
 
         bool is_sym (is_symlink(detail::symlink_status(result, ec)));
         if (ec && *ec)
-          return path();
+        {
+            if (result == preferred_separator_string && source != preferred_separator_string)
+            {
+                ec->clear();
+                continue;
+            }
+
+            return path();
+        }
 
         if (is_sym)
         {

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -829,15 +829,7 @@ namespace detail
 
         bool is_sym (is_symlink(detail::symlink_status(result, ec)));
         if (ec && *ec)
-        {
-            if (result == &path::preferred_separator && source != &path::preferred_separator)
-            {
-                ec->clear();
-                continue;
-            }
-
-            return path();
-        }
+          return path();
 
         if (is_sym)
         {

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -829,7 +829,15 @@ namespace detail
 
         bool is_sym (is_symlink(detail::symlink_status(result, ec)));
         if (ec && *ec)
-          return path();
+        {
+            if (result == &path::preferred_separator && source != &path::preferred_separator)
+            {
+                ec->clear();
+                continue;
+            }
+
+            return path();
+        }
 
         if (is_sym)
         {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -537,6 +537,12 @@ namespace
       && is_separator(path[2])) return 2;
 #   endif
 
+#   ifdef _VX_CPU
+    // case "host:" - VxWorks simulator
+    if (size > 5
+        && path[4] == colon) return 5;
+#   endif
+
     // case "//"
     if (size == 2
       && is_separator(path[0])


### PR DESCRIPTION
01 - Introduced the root path for the VxWorks simulator.
It the "host:" is not handled, this can cause infinite recursive call on
VxWorks simulator when using the canonical function

02 - Corrected path canonical function to handle properly path existence in
some platforms where the root separator might not be a valid path.
E.g.: On VxWorks the path "/" can be invalid but the path "/tgtsvr/" is
a valid path.
