### PR TITLE
Remove unused deprecated include

### DIFF
--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -31,7 +31,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/iterator.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/range/mutable_iterator.hpp>
 #include <boost/range/const_iterator.hpp>


### PR DESCRIPTION
The comment in boost/iterator.hpp mentions that the file is obsolete and will be deprecated, and it is not used anyway.

Tested with MSVC 14.