### PR TITLE
'some_function() noexcept = default;' fixes

### DIFF
--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -263,14 +263,14 @@ namespace boost
                : m_value(v), m_perms(prms) {}
 
 # ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
-    file_status(const file_status&) BOOST_NOEXCEPT = default;
-    file_status& operator=(const file_status&) BOOST_NOEXCEPT = default;
+    file_status(const file_status&) = default;
+    file_status& operator=(const file_status&) = default;
 # endif
 
 # if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #  if !defined(BOOST_FILESYSTEM_NO_CXX11_DEFAULTED_RVALUE_REFS)
-    file_status(file_status&&) BOOST_NOEXCEPT = default;
-    file_status& operator=(file_status&&) BOOST_NOEXCEPT = default;
+    file_status(file_status&&) = default;
+    file_status& operator=(file_status&&) = default;
 #  else
     file_status(file_status&& rhs) BOOST_NOEXCEPT
     {
@@ -762,8 +762,8 @@ public:
 
 # if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #  if !defined(BOOST_FILESYSTEM_NO_CXX11_DEFAULTED_RVALUE_REFS)
-    directory_entry(directory_entry&&) BOOST_NOEXCEPT = default;
-    directory_entry& operator=(directory_entry&&) BOOST_NOEXCEPT = default;
+    directory_entry(directory_entry&&) = default;
+    directory_entry& operator=(directory_entry&&) = default;
 #  else
     directory_entry(directory_entry&& rhs) BOOST_NOEXCEPT
     {

--- a/include/boost/filesystem/path.hpp
+++ b/include/boost/filesystem/path.hpp
@@ -150,8 +150,8 @@ namespace filesystem
 
 # if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #  if !defined(BOOST_FILESYSTEM_NO_CXX11_DEFAULTED_RVALUE_REFS)
-    path(path&&) BOOST_NOEXCEPT = default;
-    path& operator=(path&&) BOOST_NOEXCEPT = default;
+    path(path&&) = default;
+    path& operator=(path&&) = default;
 #  else
     path(path&& p) BOOST_NOEXCEPT
       { m_pathname = std::move(p.m_pathname); }


### PR DESCRIPTION
`some_function() noexcept = default;` seems like a bad practice. Clang3.6 will fail compilation if  exception specification of defaulted function does not match the calculated one. GCC4.8 and before also fail compilation. Latest versions of GCC silently ignore the explicit exception specification.

This pull request drops the `BOOST_NOEXCEPT` if followed by `= default`. This fixes the compilation errors like:

```
../../../boost/filesystem/operations.hpp:266:5: error: function ‘boost::filesystem::file_status::file_status(const boost::filesystem::file_status&)’ defaulted on its first declaration must not have an exception-specification

../../../boost/filesystem/operations.hpp:267:18: error: function ‘boost::filesystem::file_status& boost::filesystem::file_status::operator=(const boost::filesystem::file_status&)’ defaulted on its first declaration must not have an exception-specification