### PR TITLE
filesystem: getting file_type from a directory_entry without causing a system call on linux

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -2490,6 +2490,8 @@ and permissions of a file.</p>
         file_status  status(system::error_code&amp; ec) const;
         file_status  symlink_status() const;
         file_status  symlink_status(system::error_code&amp; ec) const;
+        file_type    symlink_type() const;
+        file_type    symlink_type(system::error_code& ec) const;
 
         bool operator&lt; (const directory_entry&amp; rhs);
         bool operator==(const directory_entry&amp; rhs); 
@@ -2649,7 +2651,21 @@ file_status  symlink_status(system::error_code&amp; ec) const;</pre>
   <p><i>Returns:</i> <code>m_symlink_status</code></p>
   
   <p><i>Throws:</i> As specified in <a href="#Error-reporting">Error reporting</a>.</p>
+</blockquote>
+  <pre>file_type  symlink_type() const;
+file_type  symlink_type(system::error_code&amp; ec) const;</pre>
+<blockquote>
+<p>
+  <i>Effects:</i> As if,</p>
+  <blockquote>
+    <pre>if ( !type_present( m_symlink_status ) )
+{
+  m_symlink_status = symlink_status(m_path<i>[, ec]</i>);
+}</pre>
+  </blockquote>
+  <p><i>Returns:</i> <code>m_symlink_status.type()</code></p>
   
+  <p><i>Throws:</i> As specified in <a href="#Error-reporting">Error reporting</a>.</p>
 </blockquote>
 <pre>bool operator==(const directory_entry&amp; rhs);</pre>
 <blockquote>

--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -813,6 +813,13 @@ public:
   file_status   symlink_status() const                        {return m_get_symlink_status();}
   file_status   symlink_status(system::error_code& ec) const BOOST_NOEXCEPT
                                                               {return m_get_symlink_status(&ec); }
+  // Return the same value as symlink_status().type(), but can be optimized in
+  // some cases avoiding a system call. E.g. on Linux the type is known from when
+  // iterating a directory, but the mode is not. Thus symlink_status causes a lstat
+  // that can be omitted if the filesystem supports it with symlink_type.
+  file_type     symlink_type() const                          {return m_get_symlink_type();}
+  file_type     symlink_type(system::error_code& ec) const BOOST_NOEXCEPT
+                                                              {return m_get_symlink_type(&ec); }
 
   bool operator==(const directory_entry& rhs) const BOOST_NOEXCEPT {return m_path == rhs.m_path; }
   bool operator!=(const directory_entry& rhs) const BOOST_NOEXCEPT {return m_path != rhs.m_path;} 
@@ -828,6 +835,7 @@ private:
 
   file_status m_get_status(system::error_code* ec=0) const;
   file_status m_get_symlink_status(system::error_code* ec=0) const;
+  file_type   m_get_symlink_type(system::error_code* ec=0) const;
 }; // directory_entry
 
 //--------------------------------------------------------------------------------------//

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1963,6 +1963,15 @@ namespace detail
     return m_symlink_status;
   }
 
+  file_type
+  directory_entry::m_get_symlink_type(system::error_code* ec) const
+  {
+    if (!type_present(m_symlink_status))
+      m_symlink_status = detail::symlink_status(m_path, ec);
+    else if (ec != 0) ec->clear();
+    return m_symlink_status.type();
+  }
+
 //  dispatch directory_entry supplied here rather than in 
 //  <boost/filesystem/path_traits.hpp>, thus avoiding header circularity.
 //  test cases are in operations_unit_test.cpp


### PR DESCRIPTION
Trac https://svn.boost.org/trac/boost/ticket/11947

When iterating over a directory with directory_iterator the directory_entries are created with the file_type component of the m_symlink_status defined if the filesystem supports it on Linux due to BOOST_FILESYSTEM_STATUS_CACHE.

However the directory iteration does not produce the permission component of the file status. Thus if using somedirectoryentry.symlink_status().type() the library performs a superfluous lstat system call because status_known does not succeed due to permissions_present not succeeding.

This is possible to fix e.g. by adding a symlink_type method to the directory_entry class, a patch implementing it is linked below:
