### PR TITLE
Fix for Ticket #6187 boost::filesystem::exists will thought a string…

### DIFF
--- a/include/boost/filesystem/path.hpp
+++ b/include/boost/filesystem/path.hpp
@@ -146,8 +146,12 @@ namespace filesystem
 
     path(const value_type* s) : m_pathname(s) {}
     path(value_type* s) : m_pathname(s) {}
-    path(const string_type& s) : m_pathname(s) {}
-    path(string_type& s) : m_pathname(s) {}
+    path(const string_type& s) : m_pathname(s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+    }
+    path(string_type& s) : m_pathname(s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+    }
 
   //  As of October 2015 the interaction between noexcept and =default is so troublesome
   //  for VC++, GCC, and probably other compilers, that =default is not used with noexcept
@@ -213,8 +217,14 @@ namespace filesystem
                                           {m_pathname = ptr; return *this;}
     path& operator=(value_type* ptr)  // required in case ptr overlaps *this
                                           {m_pathname = ptr; return *this;}
-    path& operator=(const string_type& s) {m_pathname = s; return *this;}
-    path& operator=(string_type& s)       {m_pathname = s; return *this;}
+    path& operator=(const string_type& s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+        m_pathname = s; return *this;
+    }
+    path& operator=(string_type& s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+        m_pathname = s; return *this;
+    }
 
     path& assign(const value_type* ptr, const codecvt_type&)  // required in case ptr overlaps *this
                                           {m_pathname = ptr; return *this;}
@@ -266,8 +276,14 @@ namespace filesystem
     path& operator+=(const path& p)         { m_pathname += p.m_pathname; return *this; }
     path& operator+=(const value_type* ptr) { m_pathname += ptr; return *this; }
     path& operator+=(value_type* ptr)       { m_pathname += ptr; return *this; }
-    path& operator+=(const string_type& s)  { m_pathname += s; return *this; }
-    path& operator+=(string_type& s)        { m_pathname += s; return *this; }
+    path& operator+=(const string_type& s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+        m_pathname += s; return *this;
+    }
+    path& operator+=(string_type& s) {
+	BOOST_ASSERT( s.size() == std::char_traits<value_type>::length(s.data()) );
+        m_pathname += s; return *this;
+    }
     path& operator+=(value_type c)          { m_pathname += c; return *this; }
 
     template <class CharT>


### PR DESCRIPTION
Hello,

  This pull request results from the [Bug Ticket #6187](https://svn.boost.org/trac/boost/ticket/6187). The issue demonstrates the wrong account of the null (not allowed) character in a path, which results in an undefined behavior. The bug is reproducible like following:

```
#include "boost/filesystem.hpp"
#include <iostream>

int main(int argc, char *argv[]) {

    std::basic_string<char> path = "/usr/lib/"; // It is admitted that the path exists
    path.append(2, 0x0); // Adding the 0x00 char twice
    path.append(3, 'x'); // Adding 'xxx'

    std::cout << path <<  " --- " << boost::filesystem::is_directory(path) << std::endl; //the result is 14 --- 1. It should be 9 --- 0
    return 0;
}
```

The bug fix takes part during the construction of b`oost::filesystem::path` by ensuring the string length is equal to the string size. The `Boost.Filesystem`'s path managment uses `std::basic_string`, which uses the size (i.e.: total number of symbols). The patch obtains the null-terminated string size using `std::char_traits<value_type>::size` method, for `BOOST_ASSERT` purpose into the `boost::filesystem::path`'s constructor, in order to avoid the `0x00` char's consideration in a path name.

Thank you in advance for taking into account this explanation and the pull request,
Have a great day !
