### PR TITLE
use the right directory_iterator contructor with the ec parameter

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -385,7 +385,9 @@ namespace
 
     if (type == fs::directory_file)  // but not a directory symlink
     {
-      for (fs::directory_iterator itr(p);
+      for (fs::directory_iterator itr = (ec != 0)
+		  ? fs::directory_iterator(p, *ec)
+		  : fs::directory_iterator(p);
             itr != end_dir_itr; ++itr)
       {
         fs::file_type tmp_type = query_file_type(itr->path(), ec);


### PR DESCRIPTION
This fixes [7307](https://svn.boost.org/trac/boost/ticket/7307l) by setting the error code to "access denied".
