### PR TITLE
Fix fs::create_directories(".") and fs::create_directories("..") internal assertion failure

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -937,9 +937,9 @@ namespace detail
  BOOST_FILESYSTEM_DECL
   bool create_directories(const path& p, system::error_code* ec)
   {
-    if (p.filename_is_dot() || p.filename_is_dot_dot())
+    if ((p.filename_is_dot() || p.filename_is_dot_dot()) && p.has_parent_path())
       return create_directories(p.parent_path(), ec);
-    
+
     error_code local_ec;
     file_status p_status = status(p, local_ec);
 

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -1102,7 +1102,9 @@ namespace
   {
     cout << "create_directories_tests..." << endl;
 
-    BOOST_TEST(!fs::create_directories("/")); 
+    BOOST_TEST(!fs::create_directories("/"));
+    BOOST_TEST(!fs::create_directories("."));
+    BOOST_TEST(!fs::create_directories(".."));
 
     fs::path p = dir / "level1/." / "level2/./.." / "level3/";
     // trailing "/.", "/./..", and "/" in the above elements test ticket #7258 and


### PR DESCRIPTION
Hi,

I am having regressions between Boost 1.59 and 1.61 when calling fs::create_directories(".") or fs::create_directories(".."). It now fails with:
Assertion `(parent != p)&&("internal error: p == p.parent_path()")'

This is because "..".parent() is empty, and calling fs::create_directories("") is actually invalid.

Is this OK for the trunk ?

Cheers,
Romain