### PR TITLE
Create_directories issues fix 

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -937,9 +937,20 @@ namespace detail
  BOOST_FILESYSTEM_DECL
   bool create_directories(const path& p, system::error_code* ec)
   {
+    if (p.empty())
+    {
+      if (ec != 0)
+        ec->assign(system::errc::no_such_file_or_directory,
+          system::generic_category());
+        return false;
+    }
+
     if (p.filename_is_dot() || p.filename_is_dot_dot())
       return create_directories(p.parent_path(), ec);
-    
+
+    if (p.has_root_directory() && p.root_directory() == p.parent_path())
+      return create_directory(p, ec);
+
     error_code local_ec;
     file_status p_status = status(p, local_ec);
 

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -1028,6 +1028,7 @@ namespace
 
     BOOST_TEST(!fs::create_directory("."));
     BOOST_TEST(!fs::create_directory(".."));
+    BOOST_TEST(!fs::create_directory(" "));
 
     // create a directory, then check it for consistency
     //   take extra care to report problems, since if this fails
@@ -1103,6 +1104,10 @@ namespace
     cout << "create_directories_tests..." << endl;
 
     BOOST_TEST(!fs::create_directories("/")); 
+    BOOST_TEST(!fs::create_directories(" "));
+    BOOST_TEST(!fs::create_directories(""));
+    BOOST_TEST(!fs::create_directories("."));
+    BOOST_TEST(!fs::create_directories(".."));
 
     fs::path p = dir / "level1/." / "level2/./.." / "level3/";
     // trailing "/.", "/./..", and "/" in the above elements test ticket #7258 and
@@ -1120,6 +1125,24 @@ namespace
       BOOST_TEST(!fs::create_directories("/permissions_test", ec));
       BOOST_TEST(!fs::create_directories("/permissions_test/another_directory", ec));
       BOOST_TEST(ec);
+    }
+
+    fs::path pPhantom = "/phantom";
+    try {
+      BOOST_TEST(!fs::create_directories(pPhantom));
+    }
+    catch (const fs::filesystem_error & x)
+    {
+      cout << x.what() << "\n\n"
+         "***** Creating directory " << pPhantom << " failed.   *****\n";
+    }
+
+    //should not throw
+    {
+      error_code ec;
+      BOOST_TEST(!fs::create_directories(pPhantom, ec));
+      BOOST_TEST(ec.value());
+      BOOST_TEST(ec.category() == system_category());
     }
   }
 


### PR DESCRIPTION
Hello,

This is a fix for:
- the 2 opened tickets
     https://svn.boost.org/trac/boost/ticket/12495  
     https://svn.boost.org/trac/boost/ticket/9060
- the crash when creating a directory on / with no sudo rights

Thanks,
Charles