### PR TITLE
Ticket #12578: Make directory iterators able to detect when a copy has advanced to the end

### DIFF
--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -939,7 +939,12 @@ namespace detail
     void increment() { detail::directory_iterator_increment(*this, 0); }
 
     bool equal(const directory_iterator& rhs) const
-      { return m_imp == rhs.m_imp; }
+    {
+      const bool is_lhs_valid = m_imp && m_imp->handle;
+      const bool is_rhs_valid = rhs.m_imp && rhs.m_imp->handle;
+      return (is_lhs_valid && is_rhs_valid && m_imp == rhs.m_imp)
+        || (!is_lhs_valid && !is_rhs_valid);
+    }
 
   };  // directory_iterator
 
@@ -1283,7 +1288,12 @@ namespace filesystem
     }
 
     bool equal(const recursive_directory_iterator& rhs) const
-      { return m_imp == rhs.m_imp; }
+    {
+      const bool is_lhs_valid = m_imp && !m_imp->m_stack.empty();
+      const bool is_rhs_valid = rhs.m_imp && !rhs.m_imp->m_stack.empty();
+      return (is_lhs_valid && is_rhs_valid && m_imp == rhs.m_imp)
+        || (!is_lhs_valid && !is_rhs_valid);
+    }
 
   };  // recursive directory iterator
 

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -598,6 +598,13 @@ namespace
       BOOST_TEST(++di != fs::directory_iterator());
     }
 
+    // Make invalidated directory iterators detectable (trac #12578)
+    {
+      fs::directory_iterator di( "." ), end;
+      std::distance( di, end ); // iterate a copy of di to the end iter
+      BOOST_TEST( di == end );
+    }
+
     cout << "  directory_iterator_tests complete" << endl;
   }
 
@@ -641,6 +648,13 @@ namespace
     BOOST_TEST(!ec);
     BOOST_TEST_EQ(d1f1_count, 1);
 
+    // Make invalidated directory iterators detectable (trac #12578)
+    {
+      fs::recursive_directory_iterator di( "." ), end;
+      std::distance( di, end ); // iterate a copy of di to the end iter
+      BOOST_TEST( di == end );
+    }    
+     
     cout << "  recursive_directory_iterator_tests complete" << endl;
   }
 


### PR DESCRIPTION
Motivating example is using an iterator (e.g., testing to see if it is at the end) after a copy of it has been advanced to the end:
```cpp
auto di = fs::directory_iterator( "." );
const auto end = fs::directory_iterator();
const auto dist = std::distance( di, end ); // implicitly iterate a copy of di to the end
                                            // which makes di undetectably invalid.
std::cout << "File count: " << dist << std::endl;
while( di++ != end ) // crash! Also with: for( const auto& e : di ), etc.
{
  std::cout << *di << std::endl;
}
```
For details, see [Ticket #12578](https://svn.boost.org/trac/boost/ticket/12578).

