### PR TITLE
Fix errno propagation in space(p, ec).

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1620,7 +1620,7 @@ namespace detail
 #   ifdef BOOST_POSIX_API
     struct BOOST_STATVFS vfs;
     space_info info;
-    if (!error(::BOOST_STATVFS(p.c_str(), &vfs)!= 0,
+    if (!error(::BOOST_STATVFS(p.c_str(), &vfs) ? BOOST_ERRNO : 0,
       p, ec, "boost::filesystem::space"))
     {
       info.capacity 


### PR DESCRIPTION
The space(p, ec) implementation assigned a wrong
error value to the given error_code object.
Instead of getting the error value from errno,
the code used the value '-1!=0'.

Signed-off-by: Christoph Müllner <christophm30@gmail.com>