### PR TITLE
Fix #12759: add definitions of constexpr path members

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -125,6 +125,10 @@ namespace boost
 {
 namespace filesystem
 {
+  BOOST_CONSTEXPR value_type path::separator;
+  BOOST_CONSTEXPR value_type path::preferred_separator;
+  BOOST_CONSTEXPR value_type path::dot;
+
   path& path::operator/=(const path& p)
   {
     if (p.empty())

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -1939,6 +1939,12 @@ static boost::filesystem::path ticket_6737 = "FilePath";  // #6737 reported this
                                                           // on VC++ debug mode build 
 const boost::filesystem::path ticket_6690("test");  // #6690 another V++ static init crash
 
+void ticket_12759(const path::value_type &) {
+  ticket_12759(path::separator);
+  ticket_12759(path::preferred_separator);
+  ticket_12759(path::dot);
+}
+
 //--------------------------------------------------------------------------------------//
 //                                                                                      //
 //                                     main                                             //


### PR DESCRIPTION
A possible fix for https://svn.boost.org/trac/boost/ticket/12759