### PR TITLE
noexcept is_empty throws on missing permissions.

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -8,17 +8,17 @@
 
 //  See library home page at http://www.boost.org/libs/filesystem
 
-//--------------------------------------------------------------------------------------// 
+//--------------------------------------------------------------------------------------//
 
-//  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
+//  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355)
 #if !(defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED))
 #define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #endif
 #if !defined(__PGI)
 #define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
-      // 64-bit systems or on 32-bit systems which don't have files larger 
-      // than can be represented by a traditional POSIX/UNIX off_t type. 
-      // OTOH, defining them should kick in 64-bit off_t's (and thus 
+      // 64-bit systems or on 32-bit systems which don't have files larger
+      // than can be represented by a traditional POSIX/UNIX off_t type.
+      // OTOH, defining them should kick in 64-bit off_t's (and thus
       // st_size)on 32-bit systems that provide the Large File
       // Support (LFS)interface, such as Linux, Solaris, and IRIX.
       // The defines are given before any headers are included to
@@ -31,9 +31,9 @@
 
 // define BOOST_FILESYSTEM_SOURCE so that <boost/filesystem/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#define BOOST_FILESYSTEM_SOURCE 
+#define BOOST_FILESYSTEM_SOURCE
 
-#ifndef BOOST_SYSTEM_NO_DEPRECATED 
+#ifndef BOOST_SYSTEM_NO_DEPRECATED
 # define BOOST_SYSTEM_NO_DEPRECATED
 #endif
 
@@ -44,11 +44,11 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/detail/workaround.hpp>
-#include <vector> 
+#include <vector>
 #include <cstdlib>     // for malloc, free
 #include <cstring>
 #include <cstdio>      // for remove, rename
-#if defined(__QNXNTO__)  // see ticket #5355 
+#if defined(__QNXNTO__)  // see ticket #5355
 # include <stdio.h>
 #endif
 #include <cerrno>
@@ -116,7 +116,7 @@ using std::wstring;
 #     include <sys/utime.h>
 #   endif
 
-//  REPARSE_DATA_BUFFER related definitions are found in ntifs.h, which is part of the 
+//  REPARSE_DATA_BUFFER related definitions are found in ntifs.h, which is part of the
 //  Windows Device Driver Kit. Since that's inconvenient, the definitions are provided
 //  here. See http://msdn.microsoft.com/en-us/library/ms791514.aspx
 
@@ -169,7 +169,7 @@ typedef struct _REPARSE_DATA_BUFFER {
 # endif
 
 # ifndef IO_REPARSE_TAG_SYMLINK
-#   define IO_REPARSE_TAG_SYMLINK (0xA000000CL)       
+#   define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
 # endif
 
 inline std::wstring wgetenv(const wchar_t* name)
@@ -209,7 +209,7 @@ inline std::wstring wgetenv(const wchar_t* name)
 typedef int err_t;
 
 //  POSIX uses a 0 return to indicate success
-#   define BOOST_ERRNO    errno 
+#   define BOOST_ERRNO    errno
 #   define BOOST_SET_CURRENT_DIRECTORY(P)(::chdir(P)== 0)
 #   define BOOST_CREATE_DIRECTORY(P)(::mkdir(P, S_IRWXU|S_IRWXG|S_IRWXO)== 0)
 #   define BOOST_CREATE_HARD_LINK(F,T)(::link(T, F)== 0)
@@ -280,7 +280,7 @@ namespace
     {
       if (ec != 0) ec->clear();
     }
-    else  
+    else
     { //  error
       if (ec == 0)
         BOOST_FILESYSTEM_THROW(filesystem_error(message,
@@ -297,7 +297,7 @@ namespace
     {
       if (ec != 0) ec->clear();
     }
-    else  
+    else
     { //  error
       if (ec == 0)
         BOOST_FILESYSTEM_THROW(filesystem_error(message,
@@ -315,7 +315,7 @@ namespace
     {
       if (ec != 0) ec->clear();
     }
-    else  
+    else
     { //  error
       if (ec == 0)
         BOOST_FILESYSTEM_THROW(filesystem_error(message,
@@ -328,27 +328,30 @@ namespace
 
   //  general helpers  -----------------------------------------------------------------//
 
-  bool is_empty_directory(const path& p)
+  bool is_empty_directory(const path& p, error_code* ec)
   {
-    return fs::directory_iterator(p)== end_dir_itr;
+    if (ec != 0)
+      return fs::directory_iterator(p, *ec) == end_dir_itr;
+    else
+      return fs::directory_iterator(p) == end_dir_itr;
   }
 
   bool not_found_error(int errval); // forward declaration
 
   // only called if directory exists
   bool remove_directory(const path& p) // true if succeeds or not found
-  { 
+  {
     return BOOST_REMOVE_DIRECTORY(p.c_str())
       || not_found_error(BOOST_ERRNO);  // mitigate possible file system race. See #11166
   }
-  
+
   // only called if file exists
   bool remove_file(const path& p) // true if succeeds or not found
   {
     return BOOST_DELETE_FILE(p.c_str())
       || not_found_error(BOOST_ERRNO);  // mitigate possible file system race. See #11166
   }
-  
+
   // called by remove and remove_all_aux
   bool remove_file_or_directory(const path& p, fs::file_type type, error_code* ec)
     // return true if file removed, false if not removed
@@ -438,7 +441,7 @@ namespace
 
     struct stat from_stat;
     if (::stat(from_p.c_str(), &from_stat)!= 0)
-    { 
+    {
       ::close(infile);
       return false;
     }
@@ -471,7 +474,7 @@ namespace
           // and #2 below added to verify that analysis.
         if ((sz = ::write(outfile, buf.get() + sz_write,
           sz_read - sz_write)) < 0)
-        { 
+        {
           sz_read = sz; // cause read loop termination
           break;        //  and error reported after closes
         }
@@ -567,7 +570,7 @@ namespace
   }
 
   // Thanks to Jeremy Maitin-Shepard for much help and for permission to
-  // base the equivalent()implementation on portions of his 
+  // base the equivalent()implementation on portions of his
   // file-equivalence-win32.cpp experimental code.
 
   struct handle_wrapper
@@ -600,8 +603,8 @@ namespace
     if (h.handle == INVALID_HANDLE_VALUE)
       return false;
 
-    boost::scoped_array<char> buf(new char [MAXIMUM_REPARSE_DATA_BUFFER_SIZE]);    
- 
+    boost::scoped_array<char> buf(new char [MAXIMUM_REPARSE_DATA_BUFFER_SIZE]);
+
     // Query the reparse data
     DWORD dwRetLen;
     BOOL result = ::DeviceIoControl(h.handle, FSCTL_GET_REPARSE_POINT, NULL, 0, buf.get(),
@@ -935,7 +938,7 @@ namespace detail
     error(BOOST_ERROR_NOT_SUPPORTED, new_symlink, existing_symlink, ec,
       "boost::filesystem::copy_symlink");
 
-# else  // modern Windows or BOOST_POSIX_API 
+# else  // modern Windows or BOOST_POSIX_API
     path p(read_symlink(existing_symlink, ec));
     if (ec != 0 && *ec) return;
     create_symlink(p, new_symlink, ec);
@@ -959,7 +962,7 @@ namespace detail
 
     if (p.filename_is_dot() || p.filename_is_dot_dot())
       return create_directories(p.parent_path(), ec);
-    
+
     error_code local_ec;
     file_status p_status = status(p, local_ec);
 
@@ -1105,7 +1108,7 @@ namespace detail
       if (::getcwd(buf.get(), static_cast<std::size_t>(path_max))== 0)
       {
         if (error(errno != ERANGE ? errno : 0
-      // bug in some versions of the Metrowerks C lib on the Mac: wrong errno set 
+      // bug in some versions of the Metrowerks C lib on the Mac: wrong errno set
 #         if defined(__MSL__) && (defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__))
           && errno != 0
 #         endif
@@ -1220,7 +1223,7 @@ namespace detail
     // In theory, volume serial numbers are sufficient to distinguish between
     // devices, but in practice VSN's are sometimes duplicated, so last write
     // time and file size are also checked.
-      return 
+      return
         info1.dwVolumeSerialNumber == info2.dwVolumeSerialNumber
         && info1.nFileIndexHigh == info2.nFileIndexHigh
         && info1.nFileIndexLow == info2.nFileIndexLow
@@ -1315,9 +1318,9 @@ namespace detail
     struct stat path_stat;
     if (error(::stat(p.c_str(), &path_stat)!= 0,
         p, ec, "boost::filesystem::is_empty"))
-      return false;        
+      return false;
     return S_ISDIR(path_stat.st_mode)
-      ? is_empty_directory(p)
+      ? is_empty_directory(p, ec)
       : path_stat.st_size == 0;
 #   else
 
@@ -1327,9 +1330,9 @@ namespace detail
         return false;
 
     if (ec != 0) ec->clear();
-    return 
+    return
       (fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-        ? is_empty_directory(p)
+        ? is_empty_directory(p, ec)
         : (!fad.nFileSizeHigh && !fad.nFileSizeLow);
 #   endif
   }
@@ -1569,7 +1572,7 @@ namespace detail
       return path();
     return wc_p.lexically_relative(wc_base);
   }
-  
+
   BOOST_FILESYSTEM_DECL
   bool remove(const path& p, error_code* ec)
   {
@@ -1623,9 +1626,9 @@ namespace detail
     if (!error(::BOOST_STATVFS(p.c_str(), &vfs) ? BOOST_ERRNO : 0,
       p, ec, "boost::filesystem::space"))
     {
-      info.capacity 
+      info.capacity
         = static_cast<boost::uintmax_t>(vfs.f_blocks)* BOOST_STATVFS_F_FRSIZE;
-      info.free 
+      info.free
         = static_cast<boost::uintmax_t>(vfs.f_bfree)* BOOST_STATVFS_F_FRSIZE;
       info.available
         = static_cast<boost::uintmax_t>(vfs.f_bavail)* BOOST_STATVFS_F_FRSIZE;
@@ -1810,27 +1813,27 @@ namespace detail
   {
 #   ifdef BOOST_POSIX_API
       const char* val = 0;
-      
+
       (val = std::getenv("TMPDIR" )) ||
       (val = std::getenv("TMP"    )) ||
       (val = std::getenv("TEMP"   )) ||
       (val = std::getenv("TEMPDIR"));
-      
+
 #     ifdef __ANDROID__
         const char* default_tmp = "/data/local/tmp";
 #     else
         const char* default_tmp = "/tmp";
 #     endif
       path p((val!=0) ? val : default_tmp);
-       
+
       if (p.empty() || (ec&&!is_directory(p, *ec))||(!ec&&!is_directory(p)))
       {
         error(ENOTDIR, p, ec, "boost::filesystem::temp_directory_path");
         return p;
       }
-        
+
       return p;
-      
+
 #   else  // Windows
 
       const wchar_t* tmp_env = L"TMP";
@@ -1874,7 +1877,7 @@ namespace detail
 
 #   endif
   }
-  
+
   BOOST_FILESYSTEM_DECL
   path system_complete(const path& p, system::error_code* ec)
   {
@@ -1928,7 +1931,7 @@ namespace detail
 
     bool tail_has_dots = false;
     for (; itr != p.end(); ++itr)
-    { 
+    {
       tail /= *itr;
       // for a later optimization, track if any dot or dot-dot elements are present
       if (itr->native().size() <= 2
@@ -1936,7 +1939,7 @@ namespace detail
         && (itr->native().size() == 1 || itr->native()[1] == dot))
         tail_has_dots = true;
     }
-    
+
     if (head.empty())
       return p.lexically_normal();
     head = canonical(head, tmp_ec);
@@ -1945,7 +1948,7 @@ namespace detail
     return tail.empty()
       ? head
       : (tail_has_dots  // optimization: only normalize if tail had dot or dot-dot element
-          ? (head/tail).lexically_normal()  
+          ? (head/tail).lexically_normal()
           : head/tail);
   }
 }  // namespace detail
@@ -1966,7 +1969,7 @@ namespace detail
       // symlink status to the regular status.
       if (status_known(m_symlink_status)
         && !is_symlink(m_symlink_status))
-      { 
+      {
         m_status = m_symlink_status;
         if (ec != 0) ec->clear();
       }
@@ -1985,7 +1988,7 @@ namespace detail
     return m_symlink_status;
   }
 
-//  dispatch directory_entry supplied here rather than in 
+//  dispatch directory_entry supplied here rather than in
 //  <boost/filesystem/path_traits.hpp>, thus avoiding header circularity.
 //  test cases are in operations_unit_test.cpp
 
@@ -1994,7 +1997,7 @@ namespace path_traits
   void dispatch(const directory_entry & de,
 #                ifdef BOOST_WINDOWS_API
     std::wstring& to,
-#                else   
+#                else
     std::string& to,
 #                endif
     const codecvt_type &)
@@ -2005,7 +2008,7 @@ namespace path_traits
   void dispatch(const directory_entry & de,
 #                ifdef BOOST_WINDOWS_API
     std::wstring& to
-#                else   
+#                else
     std::string& to
 #                endif
     )
@@ -2071,7 +2074,7 @@ namespace
     buffer = std::malloc((sizeof(dirent) - sizeof(de.d_name))
       +  path_size + 1); // + 1 for "/0"
     return ok;
-  }  
+  }
 
   // warning: the only dirent member updated is d_name
   inline int readdir_r_simulator(DIR * dirp, struct dirent * entry,
@@ -2152,11 +2155,11 @@ namespace
     WIN32_FIND_DATAW data;
     if ((handle = ::FindFirstFileW(dirpath.c_str(), &data))
       == INVALID_HANDLE_VALUE)
-    { 
+    {
       handle = 0;  // signal eof
       return error_code( (::GetLastError() == ERROR_FILE_NOT_FOUND
-                       // Windows Mobile returns ERROR_NO_MORE_FILES; see ticket #3551                                           
-                       || ::GetLastError() == ERROR_NO_MORE_FILES) 
+                       // Windows Mobile returns ERROR_NO_MORE_FILES; see ticket #3551
+                       || ::GetLastError() == ERROR_NO_MORE_FILES)
         ? 0 : ::GetLastError(), system_category() );
     }
     target = data.cFileName;
@@ -2228,7 +2231,7 @@ namespace
 #     ifdef BOOST_WINDOWS_API
         ERROR_PATH_NOT_FOUND
 #     else
-        ENOENT 
+        ENOENT
 #     endif
         , system_category());
 
@@ -2241,7 +2244,7 @@ namespace filesystem
 
 namespace detail
 {
-  //  dir_itr_close is called both from the ~dir_itr_imp()destructor 
+  //  dir_itr_close is called both from the ~dir_itr_imp()destructor
   //  and dir_itr_increment()
   BOOST_FILESYSTEM_DECL
   system::error_code dir_itr_close( // never throws
@@ -2271,7 +2274,7 @@ namespace detail
   }
 
   void directory_iterator_construct(directory_iterator& it,
-    const path& p, system::error_code* ec)    
+    const path& p, system::error_code* ec)
   {
     if (error(p.empty() ? not_found_error_code.value() : 0, p, ec,
               "boost::filesystem::directory_iterator::construct"))
@@ -2292,7 +2295,7 @@ namespace detail
         ec, "boost::filesystem::directory_iterator::construct");
       return;
     }
-    
+
     if (it.m_imp->handle == 0)
       it.m_imp.reset(); // eof, so make end iterator
     else // not eof
@@ -2311,7 +2314,7 @@ namespace detail
   {
     BOOST_ASSERT_MSG(it.m_imp.get(), "attempt to increment end iterator");
     BOOST_ASSERT_MSG(it.m_imp->handle != 0, "internal program error");
-    
+
     path::string_type filename;
     file_status file_stat, symlink_file_stat;
     system::error_code temp_ec;


### PR DESCRIPTION
`boost::filesystem::is_emtpy` with `boost::system::error_code` throws on missing permissions.