### PR TITLE
Fix read_symlink with windows junctions points

### DIFF
--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -1805,6 +1805,7 @@ namespace
         BOOST_TEST(!fs::is_regular_file(junc));
         BOOST_TEST(fs::exists(junc / "d1f1"));
         BOOST_TEST(fs::is_regular_file(junc / "d1f1"));
+        BOOST_TEST_EQ(fs::read_symlink(junc), dir / "d1");
 
         int count = 0;
         for (fs::directory_iterator itr(junc);
@@ -1824,6 +1825,7 @@ namespace
         BOOST_TEST(!fs::is_regular_file(new_junc));
         BOOST_TEST(fs::exists(new_junc / "d1f1"));
         BOOST_TEST(fs::is_regular_file(new_junc / "d1f1"));
+        BOOST_TEST_EQ(fs::read_symlink(new_junc), dir / "d1");
 
         fs::remove(new_junc);
         BOOST_TEST(!fs::exists(new_junc / "d1f1"));


### PR DESCRIPTION
On windows `is_symlink` considers both symbolic links and junction points to be symlinks. However `read_symlink` assumes a symbolic sink, which results in reading from bad offsets in the `REPARSE_DATA_BUFFER` struct.