### PR TITLE
Fix crash due to static variable initialization order

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -613,12 +613,12 @@ namespace
   }  
   
   typedef bool (*Ptr_equal_string_ordinal_ic)(const wchar_t*, const wchar_t*);
-
-  Ptr_equal_string_ordinal_ic equal_string_ordinal_ic = 
-    rtl_equal_unicode_string_api ? equal_string_ordinal_ic_1 : equal_string_ordinal_ic_2;
   
   perms make_permissions(const path& p, DWORD attr)
   {
+    static Ptr_equal_string_ordinal_ic equal_string_ordinal_ic =
+      rtl_equal_unicode_string_api ? equal_string_ordinal_ic_1 : equal_string_ordinal_ic_2;
+
     perms prms = fs::owner_read | fs::group_read | fs::others_read;
     if  ((attr & FILE_ATTRIBUTE_READONLY) == 0)
       prms |= fs::owner_write | fs::group_write | fs::others_write;


### PR DESCRIPTION
The static variable `equal_string_ordinal_ic` is not yet initialized when
invoking `boost::filesystem::remove_all(dir)` also at static initialization
time.

Real example code that causes the issue (global scope):

```
/// \hack
/// Forces 1 time shared memory cleanup on filesystem.
static class cleanup_shared_memory
{
public:
   cleanup_shared_memory()
   {
      try
      {
         std::string dir;
         ipcdetail::get_shared_dir_root(dir);
         boost::filesystem::remove_all(dir);
         LOG_INFO << "Removed old shared memory data: " << dir;
      }
      catch (boost::filesystem::filesystem_error const& e)
      {
         LOG_ERROR << "Could not remove old shared memory data: " << e.what();
      }
   }
} do_not_remove;
```