### PR TITLE
copy_file does not check file type, can fill disk or hang program if used on certain file types

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -445,6 +445,14 @@ namespace
       return false;
     }
 
+    // non-regular file types cannot be copied by reading and writing their contents
+    if ((from_stat.st_mode & S_IFMT) != S_IFREG)
+    {
+      BOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::copy_file_api",
+                                              from_p.c_str(), to_p.c_str(),
+					      error_code(BOOST_ERROR_NOT_SUPPORTED, system_category())));
+    }
+
     int oflag = O_CREAT | O_WRONLY | O_TRUNC;
     if (fail_if_exists)
       oflag |= O_EXCL;


### PR DESCRIPTION
Boost’s copy_file method, when passed non-regular files, can fill up the user’s disk space or hang the program.

The copy_file method does not check file type before it begins copying, which can lead to unspecified behavior if the user tries to copy a non-regular (type) file. As only regular files can be properly copied by reading and writing their contents, trying to copy non-regular files in this way can cause problems. For example:
- Trying to copy a symlink to the character device /dev/urandom with copy_file will copy random data into the output file indefinitely, quickly filling up the user’s disk. 
- Trying to copy a FIFO type file with copy_file will result in the program hanging indefinitely if left unattended.

This problem can be fixed without too much work by checking the result of the post-open stat call to check that a regular file was opened.

This problem was found as part of an effort to detect and deal with “environmental” bugs in popular applications (for more information, check out https://works-everywhere.org). It was found using a tool that detects situations where an application fails to correctly handle unusual environmental conditions such as files having an unexpected file type.