### PR TITLE
Update PGI C++ compiler support

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -2143,10 +2143,6 @@ namespace
     return ok;
   }
 
-#if defined(__PGI) && defined(__USE_FILE_OFFSET64)
-#define dirent dirent64
-#endif
-
   error_code dir_itr_first(void *& handle, void *& buffer,
     const char* dir, string& target,
     fs::file_status &, fs::file_status &)


### PR DESCRIPTION
Remove an #if from operations.cpp that used to be necessary for the file to compile with PGI C++, but causes compilation errors with PGI C++ compilers of the last few years.