### PR TITLE
Fixes static initialization fiasco crash

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -614,11 +614,11 @@ namespace
   
   typedef bool (*Ptr_equal_string_ordinal_ic)(const wchar_t*, const wchar_t*);
 
-  Ptr_equal_string_ordinal_ic equal_string_ordinal_ic = 
-    rtl_equal_unicode_string_api ? equal_string_ordinal_ic_1 : equal_string_ordinal_ic_2;
-  
   perms make_permissions(const path& p, DWORD attr)
   {
+    static Ptr_equal_string_ordinal_ic equal_string_ordinal_ic = 
+      rtl_equal_unicode_string_api ? equal_string_ordinal_ic_1 : equal_string_ordinal_ic_2;
+  
     perms prms = fs::owner_read | fs::group_read | fs::others_read;
     if  ((attr & FILE_ATTRIBUTE_READONLY) == 0)
       prms |= fs::owner_write | fs::group_write | fs::others_write;


### PR DESCRIPTION
In an application I have something like that:

    namespace blah {
        // using boost filesystem types:
        const path CACHE_DIR = system_complete( temp_directory_path() / app_directory_name );
    }

This ends up calling `make_permissions()` (the modified function of this patch) with `equal_string_ordinal_ic` being null in Debug mode in my case. It's iniitalization didn't happen before my path initialization so it's unusable.
As `equal_string_ordinal_ic` is not used outside the `make_permissions` function and is set only once, I simply made it a static local.

This works in my application (after recompiling everything).