### PR TITLE
Reset 'errno' after 'sysconf()'

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -2169,17 +2169,20 @@ namespace
   inline int readdir_r_simulator(DIR * dirp, struct dirent * entry,
     struct dirent ** result)// *result set to 0 on end of directory
   {
-    errno = 0;
-
 #   if !defined(__CYGWIN__)\
     && defined(_POSIX_THREAD_SAFE_FUNCTIONS)\
     && defined(_SC_THREAD_SAFE_FUNCTIONS)\
     && (_POSIX_THREAD_SAFE_FUNCTIONS+0 >= 0)\
     && (!defined(__hpux) || defined(_REENTRANT)) \
     && (!defined(_AIX) || defined(__THREAD_SAFE))
+
+    errno = 0;
+
     if (::sysconf(_SC_THREAD_SAFE_FUNCTIONS)>= 0)
       { return ::readdir_r(dirp, entry, result); }
 #   endif
+
+    errno = 0;
 
     struct dirent * p;
     *result = 0;


### PR DESCRIPTION
In our case (we haven't gotten to the bottom of exactly why), `sysconf()` returns -1 and sets `errno == 38` (ENOSYS). When iterating over a directory, this lead to that error incorrectly being propagated after incrementing past the last directory entry.
