### PR TITLE
Initialize function pointers at first use (II)

### DIFF
--- a/test/issues/13024-1.cpp
+++ b/test/issues/13024-1.cpp
@@ -1,0 +1,32 @@
+//  Copyright Daniel Kruegler 2017
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+#include <boost/filesystem.hpp>
+#include <boost/thread.hpp>
+
+namespace fs = boost::filesystem;
+
+struct StaticInitializer {
+  StaticInitializer() {
+    static const fs::path path = fs::current_path();
+    struct {
+      void operator()() { fs::status(path); }
+    } func;
+    const int max_count = 50;
+    boost::thread ths[max_count];
+    for (int i = 0; i < max_count; ++i) {
+      new (&ths[i]) boost::thread(func);
+    }
+    for (int i = 0; i < max_count; ++i) {
+      ths[i].join();
+    }
+  }
+} instance;
+
+int main()
+{
+}

--- a/test/issues/13024-2.cpp
+++ b/test/issues/13024-2.cpp
@@ -1,0 +1,31 @@
+//  Copyright Daniel Kruegler 2017
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+#define BOOST_TEST_MODULE issue_13024
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <vector>
+
+static std::vector<boost::filesystem::path> get_files()
+{
+    std::vector<boost::filesystem::path> result;
+    boost::system::error_code error;
+    boost::filesystem::directory_iterator it("..", error);
+    for (boost::filesystem::directory_iterator const eit; it != eit; ++it)
+        if (is_regular_file(it->status()))
+            result.push_back(it->path());
+    return result;
+}
+
+BOOST_DATA_TEST_CASE(test, get_files(), file_name)
+{
+  std::cout << file_name << std::endl;
+}


### PR DESCRIPTION
Fixes static initialization issue of new compare function using interlocked functions. Kudus to Daniela Engert for her initial pull request ff8c321a655490783c7aac589796a5ee35a749e1.