### PR TITLE
Don't use readdir_r on Linux and Android

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -2088,6 +2088,7 @@ namespace
     && defined(_POSIX_THREAD_SAFE_FUNCTIONS)\
     && defined(_SC_THREAD_SAFE_FUNCTIONS)\
     && (_POSIX_THREAD_SAFE_FUNCTIONS+0 >= 0)\
+    && !(defined(linux) || defined(__linux) || defined(__linux__))\
     && (!defined(__hpux) || defined(_REENTRANT)) \
     && (!defined(_AIX) || defined(__THREAD_SAFE))
     if (::sysconf(_SC_THREAD_SAFE_FUNCTIONS)>= 0)

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -2089,6 +2089,7 @@ namespace
     && defined(_SC_THREAD_SAFE_FUNCTIONS)\
     && (_POSIX_THREAD_SAFE_FUNCTIONS+0 >= 0)\
     && !(defined(linux) || defined(__linux) || defined(__linux__))\
+    && !defined(__ANDROID__)\
     && (!defined(__hpux) || defined(_REENTRANT)) \
     && (!defined(_AIX) || defined(__THREAD_SAFE))
     if (::sysconf(_SC_THREAD_SAFE_FUNCTIONS)>= 0)


### PR DESCRIPTION
`readdir_r` has been deprecated and has problems of its own[1]. glibc 2.24 marked
`readdir_r` as deprecated and may eventually remove it. At the same time, plain
`readdir` is thread-safe if different threads call it for different directory
streams, which is fine in our case.

[1]: http://man7.org/linux/man-pages/man3/readdir_r.3.html
