### PR TITLE
Fix compilation for Android and clean up _FILE_OFFSET_BITS #if-ery

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -26,13 +26,25 @@
 //
 // Thus we do not define _FILE_OFFSET_BITS in such case.
 #else
-// 64-bit systems or on 32-bit systems which don't have files larger
-// than can be represented by a traditional POSIX/UNIX off_t type.
-// OTOH, defining them should kick in 64-bit off_t's (and thus
-// st_size)on 32-bit systems that provide the Large File
-// Support (LFS)interface, such as Linux, Solaris, and IRIX.
-// The defines are given before any headers are included to
-// ensure that they are available to all included headers.
+// Defining _FILE_OFFSET_BITS=64 should kick in 64-bit off_t's
+// (and thus st_size) on 32-bit systems that provide the Large File
+// Support (LFS) interface, such as Linux, Solaris, and IRIX.
+//
+// At the time of this comment writing (March 2018), on most systems
+// _FILE_OFFSET_BITS=64 definition is harmless:
+// either the definition is supported and enables 64-bit off_t,
+// or the definition is not supported and is ignored, in which case
+// off_t does not change its default size for the target system
+// (which may be 32-bit or 64-bit already).
+// Thus it makes sense to have _FILE_OFFSET_BITS=64 defined by default,
+// instead of listing every system that supports the definition.
+// Those few systems, on which _FILE_OFFSET_BITS=64 is harmful,
+// for example this definition causes compilation failure on those systems,
+// should be exempt from defining _FILE_OFFSET_BITS by adding
+// an appropriate #elif block above with the appropriate comment.
+//
+// _FILE_OFFSET_BITS must be defined before any headers are included
+// to ensure that the definition is available to all included headers.
 // That is required at least on Solaris, and possibly on other
 // systems as well.
 #define _FILE_OFFSET_BITS 64

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -53,7 +53,8 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/detail/workaround.hpp>
-#include <vector> 
+#include <limits>
+#include <vector>
 #include <cstdlib>     // for malloc, free
 #include <cstring>
 #include <cstdio>      // for remove, rename
@@ -1624,6 +1625,12 @@ namespace detail
   BOOST_FILESYSTEM_DECL
   void resize_file(const path& p, uintmax_t size, system::error_code* ec)
   {
+#   if defined(BOOST_POSIX_API)
+    if (BOOST_UNLIKELY(size > static_cast< uintmax_t >((std::numeric_limits< off_t >::max)()))) {
+      error(system::errc::file_too_large, p, ec, "boost::filesystem::resize_file");
+      return;
+    }
+#   endif
     error(!BOOST_RESIZE_FILE(p.c_str(), size) ? BOOST_ERRNO : 0, p, ec,
       "boost::filesystem::resize_file");
   }

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -13,17 +13,15 @@
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
 #if defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED)
 
-#define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
+#define _FILE_OFFSET_BITS 64
 
 #elif defined(__PGI)
 
-#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #define _FILE_OFFSET_BITS 64
 
 #else
 
-#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
-#define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
+#define _FILE_OFFSET_BITS 64
       // 64-bit systems or on 32-bit systems which don't have files larger 
       // than can be represented by a traditional POSIX/UNIX off_t type. 
       // OTOH, defining them should kick in 64-bit off_t's (and thus 

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -11,10 +11,15 @@
 //--------------------------------------------------------------------------------------// 
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
-#if !(defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED))
+#if defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED)
+// Do nothing.
+#else
 #define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #endif
-#if !defined(__PGI)
+
+#if defined(__PGI)
+#define _FILE_OFFSET_BITS 64
+#else
 #define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
       // 64-bit systems or on 32-bit systems which don't have files larger 
       // than can be represented by a traditional POSIX/UNIX off_t type. 
@@ -25,8 +30,6 @@
       // ensure that they are available to all included headers.
       // That is required at least on Solaris, and possibly on other
       // systems as well.
-#else
-#define _FILE_OFFSET_BITS 64
 #endif
 
 // define BOOST_FILESYSTEM_SOURCE so that <boost/filesystem/config.hpp> knows

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -11,7 +11,21 @@
 //--------------------------------------------------------------------------------------// 
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
-
+#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ < 21
+// The newer Android NDKs (r16 and above), if compiling for older Android APIs
+// (below 21) and if _FILE_OFFSET_BITS=64 is defined, do not declare
+// truncate() function.
+// Thus, if _FILE_OFFSET_BITS=64 is defined, compilation of this file
+// (operations.cpp) will fail.
+// See https://github.com/boostorg/filesystem/issues/65 for more info.
+//
+// Android NDK developers consider it the expected behavior.
+// See their official position here:
+// - https://github.com/android-ndk/ndk/issues/501#issuecomment-326447479
+// - https://android.googlesource.com/platform/bionic/+/a34817457feee026e8702a1d2dffe9e92b51d7d1/docs/32-bit-abi.md#32_bit-abi-bugs
+//
+// Thus we do not define _FILE_OFFSET_BITS in such case.
+#else
 // 64-bit systems or on 32-bit systems which don't have files larger
 // than can be represented by a traditional POSIX/UNIX off_t type.
 // OTOH, defining them should kick in 64-bit off_t's (and thus
@@ -22,6 +36,7 @@
 // That is required at least on Solaris, and possibly on other
 // systems as well.
 #define _FILE_OFFSET_BITS 64
+#endif
 
 // define BOOST_FILESYSTEM_SOURCE so that <boost/filesystem/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -11,27 +11,17 @@
 //--------------------------------------------------------------------------------------// 
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
-#if defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED)
 
+// 64-bit systems or on 32-bit systems which don't have files larger
+// than can be represented by a traditional POSIX/UNIX off_t type.
+// OTOH, defining them should kick in 64-bit off_t's (and thus
+// st_size)on 32-bit systems that provide the Large File
+// Support (LFS)interface, such as Linux, Solaris, and IRIX.
+// The defines are given before any headers are included to
+// ensure that they are available to all included headers.
+// That is required at least on Solaris, and possibly on other
+// systems as well.
 #define _FILE_OFFSET_BITS 64
-
-#elif defined(__PGI)
-
-#define _FILE_OFFSET_BITS 64
-
-#else
-
-#define _FILE_OFFSET_BITS 64
-      // 64-bit systems or on 32-bit systems which don't have files larger 
-      // than can be represented by a traditional POSIX/UNIX off_t type. 
-      // OTOH, defining them should kick in 64-bit off_t's (and thus 
-      // st_size)on 32-bit systems that provide the Large File
-      // Support (LFS)interface, such as Linux, Solaris, and IRIX.
-      // The defines are given before any headers are included to
-      // ensure that they are available to all included headers.
-      // That is required at least on Solaris, and possibly on other
-      // systems as well.
-#endif
 
 // define BOOST_FILESYSTEM_SOURCE so that <boost/filesystem/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -11,13 +11,16 @@
 //--------------------------------------------------------------------------------------// 
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
-#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ < 21
-// The newer Android NDKs (r16 and above), if compiling for older Android APIs
-// (below 21) and if _FILE_OFFSET_BITS=64 is defined, do not declare
-// truncate() function.
-// Thus, if _FILE_OFFSET_BITS=64 is defined, compilation of this file
-// (operations.cpp) will fail.
-// See https://github.com/boostorg/filesystem/issues/65 for more info.
+#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ < 24
+// Android fully supports 64-bit file offsets only for API 24 and above.
+//
+// Trying to define _FILE_OFFSET_BITS=64 for APIs below 24
+// leads to compilation failure for one or another reason,
+// depending on target Android API level, Android NDK version,
+// used STL, order of include paths and more.
+// For more information, please see:
+// - https://github.com/boostorg/filesystem/issues/65
+// - https://github.com/boostorg/filesystem/pull/69
 //
 // Android NDK developers consider it the expected behavior.
 // See their official position here:

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -12,14 +12,17 @@
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355) 
 #if defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED)
-// Do nothing.
-#else
-#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
-#endif
 
-#if defined(__PGI)
+#define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
+
+#elif defined(__PGI)
+
+#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #define _FILE_OFFSET_BITS 64
+
 #else
+
+#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
       // 64-bit systems or on 32-bit systems which don't have files larger 
       // than can be represented by a traditional POSIX/UNIX off_t type. 


### PR DESCRIPTION
This pull requests cleans up `_FILE_OFFSET_BITS` #if-ery in `operations.cpp`, fixes compilation with new Android NDKs for old Android APIs (issue #65) and, thanks to @Lastique's patch, provides better error checking in `resize_file()` function.

Differences from other pull requests, like #52 and #67:

* Instead of taking easy approach like

```c++
#if !MY_SETUP
// I don't care about the mess here.
#endif 
```

, which may eventually lead to #if-ery like

```c++
#if !SETUP_3
#if !SETUP_2
#if !SETUP_1
...
#else
...
#endif
#endif 
#endif 
```

, I am making attempt to clean the mess and provide "flat" #if-ery like

```c++
#if SETUP_1
...
#elif SETUP_2
...
#else
...
#endif
```

* During the cleanup, it turns out the either `_FILE_OFFSET_BITS`, or `__USE_FILE_OFFSET64`, or both (!) is always defined, thus it is possible to greatly simplify the #if-ery.

* I am checking if `__ANDROID_API__` is defined. Reason: older Android NDKs, that use non-unified headers, do not define `__ANDROID_API__`.

* Unlike #52, I am including @Lastique's patch for `resize_file()` from #67.

* Unlike #67, I do not define `_FILE_OFFSET_BITS` if compiling with Crystax Android NDK. The reason is that I haven't found any proof that Crystax will somehow provide 64-bit truncate for Android APIs < 21. On the contrary, I found that on Crystax `off_t` is 32-bit: https://github.com/crystax/android-platform-bionic#lp32-abi-bugs.
