### PR TITLE
Fix canonical and read_symlink for junction points

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -792,6 +792,12 @@ path canonical(const path& p, const path& base, system::error_code* ec)
 
       result /= *itr;
 
+      // If we don't have an absolute path yet then don't check symlink status.
+      // This avoids checking "C:" which is "the current directory on drive C"
+      // and hence not what we want to check/resolve here.
+      if(!result.is_absolute())
+          continue;
+
       bool is_sym (is_symlink(detail::symlink_status(result, ec)));
       if (ec && *ec)
         return path();

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1569,7 +1569,7 @@ path read_symlink(const path& p, system::error_code* ec)
       //       -> resulting path is relative to the source
     } else
     {
-      error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::read_symlink");
+      error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "Unknown ReparseTag in boost::filesystem::read_symlink");
       return symlink_path;
     }
     symlink_path.assign(

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -795,7 +795,7 @@ path canonical(const path& p, const path& base, system::error_code* ec)
       // If we don't have an absolute path yet then don't check symlink status.
       // This avoids checking "C:" which is "the current directory on drive C"
       // and hence not what we want to check/resolve here.
-      if(!result.is_absolute())
+      if (!result.is_absolute())
           continue;
 
       bool is_sym (is_symlink(detail::symlink_status(result, ec)));
@@ -840,15 +840,15 @@ void copy(const path& from, const path& to, system::error_code* ec)
   file_status s(detail::symlink_status(from, ec));
   if (ec != 0 && *ec) return;
 
-  if(is_symlink(s))
+  if (is_symlink(s))
   {
     detail::copy_symlink(from, to, ec);
   }
-  else if(is_directory(s))
+  else if (is_directory(s))
   {
     detail::copy_directory(from, to, ec);
   }
-  else if(is_regular_file(s))
+  else if (is_regular_file(s))
   {
     detail::copy_file(from, to, detail::fail_if_exists, ec);
   }
@@ -1554,21 +1554,22 @@ path read_symlink(const path& p, system::error_code* ec)
         "boost::filesystem::read_symlink" ))
   {
     const wchar_t* buffer;
-    size_t offset, len;
-    if (info.rdb.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
+    std::size_t offset, len;
+    switch (info.rdb.ReparseTag)
     {
+    case IO_REPARSE_TAG_MOUNT_POINT:
       buffer = info.rdb.MountPointReparseBuffer.PathBuffer;
       offset = info.rdb.MountPointReparseBuffer.PrintNameOffset;
       len = info.rdb.MountPointReparseBuffer.PrintNameLength;
-    } else if (info.rdb.ReparseTag == IO_REPARSE_TAG_SYMLINK)
-    {
+      break;
+    case IO_REPARSE_TAG_SYMLINK:
       buffer = info.rdb.SymbolicLinkReparseBuffer.PathBuffer;
       offset = info.rdb.SymbolicLinkReparseBuffer.PrintNameOffset;
       len = info.rdb.SymbolicLinkReparseBuffer.PrintNameLength;
       // Note: iff info.rdb.SymbolicLinkReparseBuffer.Flags & SYMLINK_FLAG_RELATIVE
       //       -> resulting path is relative to the source
-    } else
-    {
+      break;
+    default:
       error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "Unknown ReparseTag in boost::filesystem::read_symlink");
       return symlink_path;
     }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -52,3 +52,4 @@ run quick.cpp ;
 
 # Tests for specific issues
 run issues/70-71-copy.cpp ;
+run issues/99_canonical_with_junction_point.cpp : : : <build>no <target-os>windows:<build>yes ;

--- a/test/issues/99_canonical_with_junction_point.cpp
+++ b/test/issues/99_canonical_with_junction_point.cpp
@@ -1,0 +1,61 @@
+
+
+#include <boost/filesystem.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <iostream>
+#include <vector>
+
+namespace fs = boost::filesystem;
+
+struct TmpDir
+{
+  fs::path path;
+  TmpDir(const fs::path& base): path(fs::absolute(base) / fs::unique_path())
+  {
+    fs::create_directories(path);
+  }
+  ~TmpDir()
+  {
+    boost::system::error_code ec;
+    fs::remove_all(path, ec);
+  }
+};
+
+int main()
+{
+  if(std::system("mklink /?") != 0)
+  {
+    std::cerr << "Junction points not supported. Skipping test" << std::endl;
+    return boost::report_errors();
+  }
+  const fs::path cwd = fs::current_path();
+  const TmpDir tmp(cwd);
+  const fs::path junction = tmp.path / "junction";
+  const fs::path real = tmp.path / "real";
+  const fs::path subDir = "sub";
+  fs::create_directories(real / subDir);
+  fs::current_path(tmp.path);
+  BOOST_TEST(std::system("mklink /j junction real") == 0);
+  BOOST_TEST(fs::exists(junction));
+
+  // Due to a bug there was a dependency on the current path so try the below for all:
+  std::vector<fs::path> paths;
+  paths.push_back(cwd);
+  paths.push_back(junction);
+  paths.push_back(real);
+  paths.push_back(junction / subDir);
+  paths.push_back(real / subDir);
+  for (std::vector<fs::path>::iterator it = paths.begin(); it != paths.end(); ++it)
+  {
+    std::cout << "Testing in " << *it << std::endl;
+    fs::current_path(*it);
+
+    // Used by canonical, must work too
+    BOOST_TEST(fs::read_symlink(junction) == real);
+
+    BOOST_TEST(fs::canonical(junction) == real);
+    BOOST_TEST(fs::canonical(junction / subDir) == real / subDir);
+  }
+
+  return boost::report_errors();
+}

--- a/test/issues/99_canonical_with_junction_point.cpp
+++ b/test/issues/99_canonical_with_junction_point.cpp
@@ -1,4 +1,11 @@
+//  Boost operations_test.cpp  ---------------------------------------------------------//
 
+//  Copyright Alexander Grund 2020
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
 
 #include <boost/filesystem.hpp>
 #include <boost/core/lightweight_test.hpp>
@@ -21,9 +28,11 @@ struct TmpDir
   }
 };
 
+// Test fs::canonical for various path in a Windows directory junction point
+// This failed before due to broken handling of absolute paths and ignored ReparseTag
 int main()
 {
-  if(std::system("mklink /?") != 0)
+  if (std::system("mklink /?") != 0)
   {
     std::cerr << "Junction points not supported. Skipping test" << std::endl;
     return boost::report_errors();


### PR DESCRIPTION
Resolving junction points in read_symlink and canonical is wrong making it unusable: It silently returns the wrong results.

Issues identified:
- read_symlink does not handle junction points and reads the wrong struct
- canonical tries to resolve the root_name as a symlink. On windows this could be `C:` and refers to the current working directory on C. Hence depending if the current dir is a symlink canonical resolves the root_name to the current dir which is wrong

Supersedes #45

- [x] Includes #142