### PR TITLE
Fixed to check readdir_r errno

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -2211,7 +2211,10 @@ namespace
     errno = 0;
 
     if (::sysconf(_SC_THREAD_SAFE_FUNCTIONS) >= 0)
-      return ::readdir_r(dirp, entry, result);
+    {
+      errno = ::readdir_r(dirp, entry, result);
+      return errno;
+    }
 #   endif
 
     errno = 0;


### PR DESCRIPTION
readdir_r() returns errno when it fails.
errno should be set properly.

Change-Id: Ia79c74bf73ebd53174ba37cb8afd2abda49c47e5
Signed-off-by: Semun Lee <semun.lee@samsung.com>