### PR TITLE
Include the public quoted header from IO

### DIFF
--- a/include/boost/filesystem/path.hpp
+++ b/include/boost/filesystem/path.hpp
@@ -29,7 +29,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/core/enable_if.hpp>
-#include <boost/io/detail/quoted_manip.hpp>
+#include <boost/io/quoted.hpp>
 #include <boost/functional/hash_fwd.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <string>


### PR DESCRIPTION
<boost/io/detail/quoted_manip.hpp> is now just a deprecated forwarding header for backward compatibility, and will be removed eventually.