### PR TITLE
Remove API level checks in symlink functions in favor of runtime checks

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1529,7 +1529,7 @@ path read_symlink(const path& p, system::error_code* ec)
 
   union info_t
   {
-    char buf[REPARSE_DATA_BUFFER_HEADER_SIZE+MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    char buf[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
     REPARSE_DATA_BUFFER rdb;
   } info;
 

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1547,10 +1547,7 @@ path read_symlink(const path& p, system::error_code* ec)
     }
   }
 
-# elif _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
-  error(BOOST_ERROR_NOT_SUPPORTED, p, ec,
-        "boost::filesystem::read_symlink");
-# else  // Vista and Server 2008 SDK, or later
+# else
 
   union info_t
   {

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -247,6 +247,11 @@ typedef struct _REPARSE_DATA_BUFFER {
 #   define BOOST_RESIZE_FILE(P,SZ)(resize_file_api(P, SZ)!= 0)
 #   define BOOST_READ_SYMLINK(P,T)
 
+// Fallback for MinGW/Cygwin
+#   ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
+#    define SYMBOLIC_LINK_FLAG_DIRECTORY 0x1
+#   endif
+
 # endif
 
 namespace boost {

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -872,16 +872,9 @@ BOOST_FILESYSTEM_DECL
 void copy_symlink(const path& existing_symlink, const path& new_symlink,
   system::error_code* ec)
 {
-# if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
-  error(BOOST_ERROR_NOT_SUPPORTED, new_symlink, existing_symlink, ec,
-    "boost::filesystem::copy_symlink");
-
-# else  // modern Windows or BOOST_POSIX_API
   path p(read_symlink(existing_symlink, ec));
   if (ec != 0 && *ec) return;
   create_symlink(p, new_symlink, ec);
-
-# endif
 }
 
 BOOST_FILESYSTEM_DECL
@@ -973,64 +966,44 @@ BOOST_FILESYSTEM_DECL
 void create_directory_symlink(const path& to, const path& from,
                                system::error_code* ec)
 {
-# if defined(BOOST_WINDOWS_API) && _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
-
-  error(BOOST_ERROR_NOT_SUPPORTED, to, from, ec,
-    "boost::filesystem::create_directory_symlink");
-# else
-
-#   if defined(BOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0600
-      // see if actually supported by Windows runtime dll
-      if (error(!create_symbolic_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
-          "boost::filesystem::create_directory_symlink"))
-        return;
-#   endif
+#if defined(BOOST_WINDOWS_API)
+  // see if actually supported by Windows runtime dll
+  if (error(!create_symbolic_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+      "boost::filesystem::create_directory_symlink"))
+    return;
+#endif
 
   error(!BOOST_CREATE_SYMBOLIC_LINK(from.c_str(), to.c_str(),
     SYMBOLIC_LINK_FLAG_DIRECTORY) ? BOOST_ERRNO : 0,
     to, from, ec, "boost::filesystem::create_directory_symlink");
-# endif
 }
 
 BOOST_FILESYSTEM_DECL
 void create_hard_link(const path& to, const path& from, error_code* ec)
 {
-# if defined(BOOST_WINDOWS_API) && _WIN32_WINNT < 0x0500  // SDK earlier than Win 2K
-
-  error(BOOST_ERROR_NOT_SUPPORTED, to, from, ec,
-    "boost::filesystem::create_hard_link");
-# else
-
-#   if defined(BOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0500
-      // see if actually supported by Windows runtime dll
-      if (error(!create_hard_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
-          "boost::filesystem::create_hard_link"))
-        return;
-#   endif
+#if defined(BOOST_WINDOWS_API)
+  // see if actually supported by Windows runtime dll
+  if (error(!create_hard_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+      "boost::filesystem::create_hard_link"))
+    return;
+#endif
 
   error(!BOOST_CREATE_HARD_LINK(from.c_str(), to.c_str()) ? BOOST_ERRNO : 0, to, from, ec,
     "boost::filesystem::create_hard_link");
-# endif
 }
 
 BOOST_FILESYSTEM_DECL
 void create_symlink(const path& to, const path& from, error_code* ec)
 {
-# if defined(BOOST_WINDOWS_API) && _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
-  error(BOOST_ERROR_NOT_SUPPORTED, to, from, ec,
-    "boost::filesystem::create_directory_symlink");
-# else
-
-#   if defined(BOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0600
-      // see if actually supported by Windows runtime dll
-      if (error(!create_symbolic_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
-          "boost::filesystem::create_symlink"))
-        return;
-#   endif
+#if defined(BOOST_WINDOWS_API)
+  // see if actually supported by Windows runtime dll
+  if (error(!create_symbolic_link_api ? BOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+      "boost::filesystem::create_symlink"))
+    return;
+#endif
 
   error(!BOOST_CREATE_SYMBOLIC_LINK(from.c_str(), to.c_str(), 0) ? BOOST_ERRNO : 0,
     to, from, ec, "boost::filesystem::create_symlink");
-# endif
 }
 
 BOOST_FILESYSTEM_DECL

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -1806,8 +1806,13 @@ namespace
       // Directory junctions are very similar to symlinks, but have some performance
       // and other advantages over symlinks. They can be created from the command line
       // with "mklink /j junction-name target-path".
-
-      if (create_symlink_ok)  // only if symlinks supported
+      
+      // Make sure that mklink does exist, it doesn't for e.g. cygwin
+      if(std::system("mklink /?") != 0)
+      {
+        cout << "  junction point could not be created." << endl;
+        cout << "  Skipping junction tests." << endl;
+      } else
       {
         cout << "  directory junction tests..." << endl;
         BOOST_TEST(fs::exists(dir));
@@ -1831,24 +1836,23 @@ namespace
         //std::system("dir");
         fs::current_path(cur_path);
         //cout << "    current_path() is " << fs::current_path() << endl;
-
+        
         BOOST_TEST(fs::exists(junc));
         BOOST_TEST(fs::is_symlink(junc));
         BOOST_TEST(fs::is_directory(junc));
         BOOST_TEST(!fs::is_regular_file(junc));
         BOOST_TEST(fs::exists(junc / "d1f1"));
         BOOST_TEST(fs::is_regular_file(junc / "d1f1"));
-
+        
         int count = 0;
-        for (fs::directory_iterator itr(junc);
-          itr != fs::directory_iterator(); ++itr)
+        for (fs::directory_iterator itr(junc); itr != fs::directory_iterator(); ++itr)
         {
           //cout << itr->path() << endl;
           ++count;
         }
         cout << "    iteration count is " << count << endl;
         BOOST_TEST(count > 0);
-
+        
         fs::rename(junc, new_junc);
         BOOST_TEST(!fs::exists(junc));
         BOOST_TEST(fs::exists(new_junc));
@@ -1857,7 +1861,7 @@ namespace
         BOOST_TEST(!fs::is_regular_file(new_junc));
         BOOST_TEST(fs::exists(new_junc / "d1f1"));
         BOOST_TEST(fs::is_regular_file(new_junc / "d1f1"));
-
+        
         fs::remove(new_junc);
         BOOST_TEST(!fs::exists(new_junc / "d1f1"));
         BOOST_TEST(!fs::exists(new_junc));


### PR DESCRIPTION
#100 became big and mixed unrelated things. So here is just the part making the symlink functions available if the runtime supports it. This is done by checking whether the functions exist (as before) and the compile time checks are not required. Only issue seen is `SYMBOLIC_LINK_FLAG_DIRECTORY` being not defined on low API levels, but as other implementations do: Just define it to the documented value for those rare cases (e.g. Cygwin using a pre XP default API level)