### PR TITLE
Add WASI platform support

### DIFF
--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -54,7 +54,8 @@
   && !(defined(linux) || defined(__linux) || defined(__linux__))\
   && !defined(__ANDROID__)\
   && (!defined(__hpux) || defined(_REENTRANT)) \
-  && (!defined(_AIX) || defined(__THREAD_SAFE))
+  && (!defined(_AIX) || defined(__THREAD_SAFE))\
+  && !defined(__wasm)
 #define BOOST_FILESYSTEM_USE_READDIR_R
 #endif
 


### PR DESCRIPTION
[WASI](https://wasi.dev/) is a POSIX-like platform that has a few important differences:
  * There is no concept of a mutable current directory. However, WASI host environment can provide a directory called `.` in the filesystem namespace that fulfills a similar role.
  * There is no concept of a file mode, and no `chmod` call.
  * There is no concept of a filesystem, and no `statfs` call.
  * There is no `readdir_r` call because there are no threads.