### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/filesystem/exception.hpp
+++ b/include/boost/filesystem/exception.hpp
@@ -58,7 +58,7 @@ public:
   filesystem_error(filesystem_error const& that);
   filesystem_error& operator= (filesystem_error const& that);
 
-  ~filesystem_error() BOOST_NOEXCEPT_OR_NOTHROW;
+  ~filesystem_error() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
 
   const path& path1() const BOOST_NOEXCEPT
   {

--- a/include/boost/filesystem/fstream.hpp
+++ b/include/boost/filesystem/fstream.hpp
@@ -19,8 +19,8 @@
 # endif
 
 #include <boost/filesystem/path.hpp>
-#include <iosfwd>
 #include <fstream>
+#include <iosfwd>
 
 #include <boost/config/abi_prefix.hpp> // must be the last #include
 
@@ -97,7 +97,7 @@ namespace filesystem
     void open(const path& p, std::ios_base::openmode mode)
       { std::basic_ifstream<charT,traits>::open(p.BOOST_FILESYSTEM_C_STR, mode); }
 
-    virtual ~basic_ifstream() {}
+    ~basic_ifstream() BOOST_OVERRIDE {}
   };
 
 //--------------------------------------------------------------------------------------//
@@ -129,7 +129,7 @@ namespace filesystem
     void open(const path& p, std::ios_base::openmode mode)
       { std::basic_ofstream<charT,traits>::open(p.BOOST_FILESYSTEM_C_STR, mode); }
 
-    virtual ~basic_ofstream() {}
+    ~basic_ofstream() BOOST_OVERRIDE {}
   };
 
 //--------------------------------------------------------------------------------------//

--- a/include/boost/filesystem/path_traits.hpp
+++ b/include/boost/filesystem/path_traits.hpp
@@ -22,11 +22,11 @@
 #include <boost/system/error_code.hpp>
 #include <boost/core/enable_if.hpp>
 #include <cwchar>  // for mbstate_t
+#include <iterator>
+#include <list>
+#include <locale>
 #include <string>
 #include <vector>
-#include <list>
-#include <iterator>
-#include <locale>
 #include <boost/assert.hpp>
 // #include <iostream>   //**** comment me out ****
 
@@ -226,25 +226,25 @@ namespace path_traits {
   template <class U> inline
     void dispatch(const std::string& c, U& to, const codecvt_type& cvt)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
   }
   template <class U> inline
     void dispatch(const std::wstring& c, U& to, const codecvt_type& cvt)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
   }
   template <class U> inline
     void dispatch(const std::vector<char>& c, U& to, const codecvt_type& cvt)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
   }
   template <class U> inline
     void dispatch(const std::vector<wchar_t>& c, U& to, const codecvt_type& cvt)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
   }
 
@@ -252,25 +252,25 @@ namespace path_traits {
   template <class U> inline
     void dispatch(const std::string& c, U& to)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to);
   }
   template <class U> inline
     void dispatch(const std::wstring& c, U& to)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to);
   }
   template <class U> inline
     void dispatch(const std::vector<char>& c, U& to)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to);
   }
   template <class U> inline
     void dispatch(const std::vector<wchar_t>& c, U& to)
   {
-    if (c.size())
+    if (!c.empty())
       convert(&*c.begin(), &*c.begin() + c.size(), to);
   }
 
@@ -281,7 +281,7 @@ namespace path_traits {
     typename boost::disable_if<boost::is_array<Container>, void>::type
     dispatch(const Container & c, U& to, const codecvt_type& cvt)
   {
-    if (c.size())
+    if (!c.empty())
     {
       std::basic_string<typename Container::value_type> s(c.begin(), c.end());
       convert(s.c_str(), s.c_str()+s.size(), to, cvt);
@@ -316,7 +316,7 @@ namespace path_traits {
     typename boost::disable_if<boost::is_array<Container>, void>::type
     dispatch(const Container & c, U& to)
   {
-    if (c.size())
+    if (!c.empty())
     {
       std::basic_string<typename Container::value_type> seq(c.begin(), c.end());
       convert(seq.c_str(), seq.c_str()+seq.size(), to);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -30,12 +30,6 @@
 #include <boost/scoped_array.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/assert.hpp>
-#include <algorithm>
-#include <iterator>
-#include <utility>
-#include <cstddef>
-#include <cstring>
-#include <cassert>
 
 #ifdef BOOST_WINDOWS_API
 # include "windows_file_codecvt.hpp"
@@ -45,10 +39,16 @@
 # include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 #endif
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstring>
 #ifdef BOOST_FILESYSTEM_DEBUG
 # include <iostream>
 # include <iomanip>
 #endif
+#include <iterator>
+#include <utility>
 
 namespace fs = boost::filesystem;
 
@@ -310,7 +310,7 @@ namespace filesystem
   {
     size_type end_pos(filename_pos(m_pathname, m_pathname.size()));
 
-    bool filename_was_separator(m_pathname.size()
+    bool filename_was_separator((!m_pathname.empty())
       && detail::is_directory_separator(m_pathname[end_pos]));
 
     // skip separators unless root directory
@@ -338,7 +338,7 @@ namespace filesystem
   BOOST_FILESYSTEM_DECL path path::filename() const
   {
     size_type pos(filename_pos(m_pathname, m_pathname.size()));
-    return (m_pathname.size()
+    return ((!m_pathname.empty())
               && pos
               && detail::is_directory_separator(m_pathname[pos])
               && !is_root_separator(m_pathname, pos))
@@ -442,7 +442,7 @@ namespace filesystem
         && (itr->native())[1] == dot) // dot dot
       {
         string_type lf(temp.filename().native());
-        if (lf.size() > 0
+        if ((!lf.empty())
           && (lf.size() != 1
             || (lf[0] != dot
               && lf[0] != separator))
@@ -482,7 +482,7 @@ namespace filesystem
       }
 
       temp /= *itr;
-    };
+    }
 
     if (temp.empty())
       temp /= detail::dot_path();
@@ -669,8 +669,6 @@ namespace
     if (src[cur] == colon)
       { ++element_size; }
 #   endif
-
-    return;
   }
 
 }  // unnamed namespace

--- a/src/portability.cpp
+++ b/src/portability.cpp
@@ -56,7 +56,7 @@ namespace boost
 #   else
     BOOST_FILESYSTEM_DECL bool native(const std::string & name)
     {
-      return  name.size() != 0
+      return (!name.empty())
         && name[0] != ' '
         && name.find('/') == std::string::npos;
     }
@@ -64,13 +64,13 @@ namespace boost
 
     BOOST_FILESYSTEM_DECL bool portable_posix_name(const std::string & name)
     {
-      return name.size() != 0
+      return (!name.empty())
         && name.find_first_not_of(valid_posix) == std::string::npos;
     }
 
     BOOST_FILESYSTEM_DECL bool windows_name(const std::string & name)
     {
-      return name.size() != 0
+      return (!name.empty())
         && name[0] != ' '
         && name.find_first_of(windows_invalid_chars) == std::string::npos
         && *(name.end()-1) != ' '
@@ -81,7 +81,7 @@ namespace boost
     BOOST_FILESYSTEM_DECL bool portable_name(const std::string & name)
     {
       return
-        name.size() != 0
+        (!name.empty())
         && (name == "."
           || name == ".."
           || (windows_name(name)

--- a/src/unique_path.cpp
+++ b/src/unique_path.cpp
@@ -39,7 +39,6 @@ void fail(int err, boost::system::error_code* ec)
       "boost::filesystem::unique_path"));
 
   ec->assign(err, boost::system::system_category());
-  return;
 }
 
 #ifdef BOOST_WINDOWS_API


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Fix Clang -Wextra-semi and Clang-tidy readability-container-size-empty and readability-redundant-control-flow warnings.
Alphabetical sort of STL headers.