### PR TITLE
is_symlink(directory_entry) should use symlink_status().

### DIFF
--- a/include/boost/filesystem/directory.hpp
+++ b/include/boost/filesystem/directory.hpp
@@ -170,7 +170,7 @@ inline bool        status_known   (const directory_entry& e) BOOST_NOEXCEPT { re
 inline bool        exists         (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::exists(e.status()); }
 inline bool        is_regular_file(const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_regular_file(e.status()); }
 inline bool        is_directory   (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_directory(e.status()); }
-inline bool        is_symlink     (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_symlink(e.status()); }
+inline bool        is_symlink     (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_symlink(e.symlink_status()); }
 inline bool        is_other       (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_other(e.status()); }
 #ifndef BOOST_FILESYSTEM_NO_DEPRECATED
 inline bool        is_regular     (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::is_regular(e.status()); }

--- a/test/operations_test.cpp
+++ b/test/operations_test.cpp
@@ -734,6 +734,7 @@ namespace
       {
         BOOST_TEST(fs::is_regular_file(it->status()));
         BOOST_TEST(fs::is_symlink(it->symlink_status()));
+        BOOST_TEST(fs::is_symlink(*it));
       }
       else if (it->path().filename() == "dangling_symlink")
       {


### PR DESCRIPTION
This fixes a problem that is_symlink(directory_entry) always returns
false, even if directory_entry is indeed a symlink. This change makes
is_symlink(directory_entry) behave the same as is_symlink(path) and
use symlink_status().