### PR TITLE
Remove workaround for OpenBSD and utilize statvfs.

### DIFF
--- a/doc/release_history.html
+++ b/doc/release_history.html
@@ -46,6 +46,7 @@
   <li>On POSIX systems, <code>file_size</code> will now indicate error code <code>errc::function_not_supported</code> if the path resolves to a non-regular file. Previously, <code>errc::operation_not_permitted</code> was reported.</li>
   <li>On Linux, many operations now use <code>statx</code> system call internally, when possible, which allows to reduce the amount of information queried from the filesystem and potentially improve performance. The <code>statx</code> system call was introduced in Linux kernel 4.11.</li>
   <li>Removed <code>const</code>-qualification from return types of some <code>path</code> methods. This could prevent move construction and move assignment at the call site in some cases. (<a href="https://github.com/boostorg/filesystem/issues/160">#160</a>)</li>
+  <li>Remove workaround for OpenBSD and utilize statvfs.
 </ul>
 
 <h2>1.74.0</h2>

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -45,14 +45,12 @@
 #   include <sys/stat.h>
 #   if defined(__wasm)
 // WASI does not have statfs or statvfs.
-#   elif !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__ANDROID__) && !defined(__VXWORKS__)
+#   elif !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__VXWORKS__)
 #     include <sys/statvfs.h>
 #     define BOOST_STATVFS statvfs
 #     define BOOST_STATVFS_F_FRSIZE vfs.f_frsize
 #   else
-#     ifdef __OpenBSD__
-#       include <sys/param.h>
-#     elif defined(__ANDROID__)
+#     if defined(__ANDROID__)
 #       include <sys/vfs.h>
 #     endif
 #     if !defined(__VXWORKS__)


### PR DESCRIPTION
OpenBSD supports statvfs. Make use of it.