### PR TITLE
Fix misplaced link opening tag for is_directory

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -133,7 +133,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#file_size">file_size</a><br>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#hard_link_count">hard_link_count</a><br>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#initial_path">initial_path</a><br>
-&nbsp;&nbsp;&nbsp;&nbsp;  i<a href="#is_directory">s_directory</a><br>
+&nbsp;&nbsp;&nbsp;&nbsp; <a href="#is_directory">is_directory</a><br>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#is_empty">is_empty</a></code></td>
     <td width="34%" valign="top">
     <p>


### PR DESCRIPTION
The opening tag was placed between the letter i and s in is_directory instead of before the i.
This PR fixes that small mistake.