### PR TITLE
Implement on top of posix API for emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(BOOST_FILESYSTEM_DISABLE_STATX OFF CACHE BOOL "Disable usage of statx API in
 set(BOOST_FILESYSTEM_DISABLE_GETRANDOM OFF CACHE BOOL "Disable usage of getrandom API in Boost.Filesystem")
 set(BOOST_FILESYSTEM_DISABLE_ARC4RANDOM OFF CACHE BOOL "Disable usage of arc4random API in Boost.Filesystem")
 set(BOOST_FILESYSTEM_DISABLE_BCRYPT OFF CACHE BOOL "Disable usage of BCrypt API in Boost.Filesystem")
-set(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI OFF CACHE BOOL "Disable usage of WASI API under emscripten and instead use the JavaScript API in Boost.Filesystem")
+set(BOOST_FILESYSTEM_EMSCRIPTEN_USE_WASI OFF CACHE BOOL "Use WASI under emscripten in Boost.Filesystem")
 
 # Note: We can't use the Boost::library targets in the configure checks as they may not yet be included
 # by the superproject when this CMakeLists.txt is included. We also don't want to hardcode include paths

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BOOST_FILESYSTEM_DISABLE_STATX OFF CACHE BOOL "Disable usage of statx API in
 set(BOOST_FILESYSTEM_DISABLE_GETRANDOM OFF CACHE BOOL "Disable usage of getrandom API in Boost.Filesystem")
 set(BOOST_FILESYSTEM_DISABLE_ARC4RANDOM OFF CACHE BOOL "Disable usage of arc4random API in Boost.Filesystem")
 set(BOOST_FILESYSTEM_DISABLE_BCRYPT OFF CACHE BOOL "Disable usage of BCrypt API in Boost.Filesystem")
+set(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI OFF CACHE BOOL "Disable usage of WASI API under emscripten and instead use the JavaScript API in Boost.Filesystem")
 
 # Note: We can't use the Boost::library targets in the configure checks as they may not yet be included
 # by the superproject when this CMakeLists.txt is included. We also don't want to hardcode include paths
@@ -130,6 +131,9 @@ if(BOOST_FILESYSTEM_DISABLE_ARC4RANDOM)
 endif()
 if(BOOST_FILESYSTEM_DISABLE_BCRYPT)
     target_compile_definitions(boost_filesystem PRIVATE BOOST_FILESYSTEM_DISABLE_BCRYPT)
+endif()
+if(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI)
+    target_compile_definitions(boost_filesystem PRIVATE BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI)
 endif()
 
 if(BOOST_FILESYSTEM_HAS_STAT_ST_BLKSIZE)

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -38,9 +38,10 @@
 #endif
 #include <cerrno>
 
-// Use WASI when not building with emscripten or when BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI is not set
-#if defined(__wasm) && (!defined(__EMSCRIPTEN__) || !defined(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI))
-#define BOOST_FILESYSTEM_STANDALONE_WASM
+// Default to POSIX under Emscripten
+// If BOOST_FILESYSTEM_EMSCRIPTEN_USE_WASI is set, use WASI instead
+#if defined(__wasm) && (!defined(__EMSCRIPTEN__) || defined(BOOST_FILESYSTEM_EMSCRIPTEN_USE_WASI))
+#define BOOST_FILESYSTEM_USE_WASI
 #endif
 
 #ifdef BOOST_POSIX_API
@@ -48,7 +49,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_USE_WASI)
 // WASI does not have statfs or statvfs.
 #elif !defined(__APPLE__) && \
     (!defined(__OpenBSD__) || BOOST_OS_BSD_OPEN >= BOOST_VERSION_NUMBER(4, 4, 0)) && \
@@ -2210,7 +2211,7 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
     }
 
     mode_t to_mode = from_mode;
-#if !defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if !defined(BOOST_FILESYSTEM_USE_WASI)
     // Enable writing for the newly created files. Having write permission set is important e.g. for NFS,
     // which checks the file permission on the server, even if the client's file descriptor supports writing.
     to_mode |= S_IWUSR;
@@ -2329,7 +2330,7 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
     if (BOOST_UNLIKELY(err != 0))
         goto fail; // err already contains the error code
 
-#if !defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if !defined(BOOST_FILESYSTEM_USE_WASI)
     // If we created a new file with an explicitly added S_IWUSR permission,
     // we may need to update its mode bits to match the source file.
     if (to_mode != from_mode)
@@ -2765,7 +2766,7 @@ void create_symlink(path const& to, path const& from, error_code* ec)
 BOOST_FILESYSTEM_DECL
 path current_path(error_code* ec)
 {
-#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_USE_WASI)
     // Windows CE has no current directory, so everything's relative to the root of the directory tree.
     // WASI also does not support current path.
     emit_error(BOOST_ERROR_NOT_SUPPORTED, ec, "boost::filesystem::current_path");
@@ -2835,7 +2836,7 @@ path current_path(error_code* ec)
 BOOST_FILESYSTEM_DECL
 void current_path(path const& p, system::error_code* ec)
 {
-#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_USE_WASI)
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::current_path");
 #else
     error(!BOOST_SET_CURRENT_DIRECTORY(p.c_str()) ? BOOST_ERRNO : 0, p, ec, "boost::filesystem::current_path");
@@ -3321,7 +3322,7 @@ void permissions(path const& p, perms prms, system::error_code* ec)
     if ((prms & add_perms) && (prms & remove_perms)) // precondition failed
         return;
 
-#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_USE_WASI)
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::permissions");
 #elif defined(BOOST_POSIX_API)
     error_code local_ec;
@@ -3580,7 +3581,7 @@ space_info space(path const& p, error_code* ec)
     if (ec)
         ec->clear();
 
-#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_USE_WASI)
 
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::space");
 

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -38,7 +38,7 @@
 #endif
 #include <cerrno>
 
-// Use WASI when not building with emscripten or when BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI is set
+// Use WASI when not building with emscripten or when BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI is not set
 #if defined(__wasm) && (!defined(__EMSCRIPTEN__) || !defined(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI))
 #define BOOST_FILESYSTEM_STANDALONE_WASM
 #endif

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -38,8 +38,9 @@
 #endif
 #include <cerrno>
 
-#if defined(__wasm) && (defined(EMSCRIPTEN_STANDALONE_WASM) || !defined(__EMSCRIPTEN__))
-#define BOOST_STANDALONE_WASM 1
+// Use WASI when not building with emscripten or when BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI is set
+#if defined(__wasm) && (!defined(__EMSCRIPTEN__) || !defined(BOOST_FILESYSTEM_DISABLE_EMSCRIPTEN_WASI))
+#define BOOST_FILESYSTEM_STANDALONE_WASM
 #endif
 
 #ifdef BOOST_POSIX_API
@@ -47,7 +48,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(BOOST_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
 // WASI does not have statfs or statvfs.
 #elif !defined(__APPLE__) && \
     (!defined(__OpenBSD__) || BOOST_OS_BSD_OPEN >= BOOST_VERSION_NUMBER(4, 4, 0)) && \
@@ -2209,7 +2210,7 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
     }
 
     mode_t to_mode = from_mode;
-#if !defined(BOOST_STANDALONE_WASM)
+#if !defined(BOOST_FILESYSTEM_STANDALONE_WASM)
     // Enable writing for the newly created files. Having write permission set is important e.g. for NFS,
     // which checks the file permission on the server, even if the client's file descriptor supports writing.
     to_mode |= S_IWUSR;
@@ -2328,7 +2329,7 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
     if (BOOST_UNLIKELY(err != 0))
         goto fail; // err already contains the error code
 
-#if !defined(BOOST_STANDALONE_WASM)
+#if !defined(BOOST_FILESYSTEM_STANDALONE_WASM)
     // If we created a new file with an explicitly added S_IWUSR permission,
     // we may need to update its mode bits to match the source file.
     if (to_mode != from_mode)
@@ -2764,7 +2765,7 @@ void create_symlink(path const& to, path const& from, error_code* ec)
 BOOST_FILESYSTEM_DECL
 path current_path(error_code* ec)
 {
-#if defined(UNDER_CE) || defined(BOOST_STANDALONE_WASM)
+#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_STANDALONE_WASM)
     // Windows CE has no current directory, so everything's relative to the root of the directory tree.
     // WASI also does not support current path.
     emit_error(BOOST_ERROR_NOT_SUPPORTED, ec, "boost::filesystem::current_path");
@@ -2834,7 +2835,7 @@ path current_path(error_code* ec)
 BOOST_FILESYSTEM_DECL
 void current_path(path const& p, system::error_code* ec)
 {
-#if defined(UNDER_CE) || defined(BOOST_STANDALONE_WASM)
+#if defined(UNDER_CE) || defined(BOOST_FILESYSTEM_STANDALONE_WASM)
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::current_path");
 #else
     error(!BOOST_SET_CURRENT_DIRECTORY(p.c_str()) ? BOOST_ERRNO : 0, p, ec, "boost::filesystem::current_path");
@@ -3320,7 +3321,7 @@ void permissions(path const& p, perms prms, system::error_code* ec)
     if ((prms & add_perms) && (prms & remove_perms)) // precondition failed
         return;
 
-#if defined(BOOST_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::permissions");
 #elif defined(BOOST_POSIX_API)
     error_code local_ec;
@@ -3579,7 +3580,7 @@ space_info space(path const& p, error_code* ec)
     if (ec)
         ec->clear();
 
-#if defined(BOOST_STANDALONE_WASM)
+#if defined(BOOST_FILESYSTEM_STANDALONE_WASM)
 
     emit_error(BOOST_ERROR_NOT_SUPPORTED, p, ec, "boost::filesystem::space");
 


### PR DESCRIPTION
I want to add a set of defines that correctly implement this library when compiling on top of emscripten.

Some explanation about the checked defines:

- ~~The `EMSCRIPTEN_STANDALONE_WASM` is defined when you build with `-s STANDALONE_WASM` so that case should still be ignored/left unimplemented~~

- ~~When the above is not set and `__EMSCRIPTEN__` is defined, it's safe to assume that the js library is bundled that implemented the posix filesystem API.~~

> Apparently `EMSCRIPTEN_STANDALONE_WASM` is only set during linking so it's not useful in this case

I saw  https://github.com/boostorg/filesystem/pull/230 , which seems to want to do the same but this should work for both the standalone/emscripten case