### PR TITLE
Limit the buffer size for compatibility with previous versions of Windows

### DIFF
--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -599,9 +599,12 @@ extra_data_format g_extra_data_format = file_directory_information_format;
  * \brief Extra buffer size for GetFileInformationByHandleEx-based or NtQueryDirectoryFile-based directory iterator.
  *
  * Must be large enough to accommodate at least one FILE_DIRECTORY_INFORMATION or *_DIR_INFO struct and one filename.
- * NTFS, VFAT, exFAT support filenames up to 255 UTF-16/UCS-2 characters. ReFS supports filenames up to 32768 UTF-16 characters.
+ * NTFS, VFAT, exFAT and ReFS support filenames up to 255 UTF-16/UCS-2 characters.
+ * The buffer cannot be larger than 64k, because up to Windows 8.1, NtQueryDirectoryFile and GetFileInformationByHandleEx
+ * fail with ERROR_INVALID_PARAMETER when trying to retrieve the filenames from a network share which shares a folder
+ * in the local computer.
  */
-BOOST_CONSTEXPR_OR_CONST std::size_t dir_itr_extra_size = sizeof(file_id_extd_dir_info) + 65536u;
+BOOST_CONSTEXPR_OR_CONST std::size_t dir_itr_extra_size = 65536u;
 
 inline system::error_code dir_itr_close(dir_itr_imp& imp) BOOST_NOEXCEPT
 {


### PR DESCRIPTION
Windows API functions NtQueryDirectoryFile and GetFileInformationByHandleEx can fail with ERROR_INVALID_PARAMETER if the provided buffer is greater than 64k, and the file handle refers to a directory located on a network share, and the shared folder is itself in the local computer. This was reproduced on Windows 7 and 8.1, but *not* on a early release of Windows 10 (v2004).

I could not find any documentation regarding this issue, apart from a brief comment on another open-source project:
[https://github.com/FarGroup/FarManager/blob/master/far/platform.fs.cpp#L620](https://github.com/FarGroup/FarManager/blob/master/far/platform.fs.cpp#L620)

The argument to have a buffer greater than 64k is based on the claim that ReFS supports filenames up to 32768 UTF-16 characters, but I could not find any documentation supporting this claim. In contrast, I found this Microsoft 
[documentation](https://docs.microsoft.com/en-us/windows-server/storage/refs/refs-overview#limits) that mentions the maximum filename length to be 255 for both NTFS and ReFS.

Therefore, I believe 64k should be enough.