### PR TITLE
Fixes 179: Consider adding a flag for ignoring fchmod errors in copy_file

### DIFF
--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -59,7 +59,7 @@ BOOST_SCOPED_ENUM_UT_DECLARE_BEGIN(copy_options, unsigned int)
     update_existing = 1u << 2,    // Overwrite existing file if its last write time is older than the replacement file
     synchronize_data = 1u << 3,   // Flush all buffered data written to the target file to permanent storage
     synchronize = 1u << 4,        // Flush all buffered data and attributes written to the target file to permanent storage
-	skip_fchmod_failure = 1 << 7, // Skip the error when fchmod fails while setting file mode bits
+    skip_fchmod_failure = 1 << 7, // Skip the error when fchmod fails while setting file mode bits
 	
     // copy options:
     recursive = 1u << 8,          // Recurse into sub-directories

--- a/include/boost/filesystem/operations.hpp
+++ b/include/boost/filesystem/operations.hpp
@@ -59,7 +59,8 @@ BOOST_SCOPED_ENUM_UT_DECLARE_BEGIN(copy_options, unsigned int)
     update_existing = 1u << 2,    // Overwrite existing file if its last write time is older than the replacement file
     synchronize_data = 1u << 3,   // Flush all buffered data written to the target file to permanent storage
     synchronize = 1u << 4,        // Flush all buffered data and attributes written to the target file to permanent storage
-
+	skip_fchmod_failure = 1 << 7, // Skip the error when fchmod fails while setting file mode bits
+	
     // copy options:
     recursive = 1u << 8,          // Recurse into sub-directories
     copy_symlinks = 1u << 9,      // Copy symlinks as symlinks instead of copying the referenced file

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -3182,9 +3182,9 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
 #if !defined(BOOST_FILESYSTEM_USE_WASI)
     // If we created a new file with an explicitly added S_IWUSR permission,
     // we may need to update its mode bits to match the source file.
-    if (BOOST_UNLIKELY(::fchmod(outfile.fd, from_mode) != 0) && (options & static_cast<unsigned int>(copy_options::skip_fchmod_failure)) == 0u )
+    if (to_mode != from_mode)
     {
-        if (BOOST_UNLIKELY(::fchmod(outfile.fd, from_mode) != 0))
+        if (BOOST_UNLIKELY(::fchmod(outfile.fd, from_mode) != 0) && (options & static_cast<unsigned int>(copy_options::skip_fchmod_failure)) == 0u )
             goto fail_errno;
     }
 #endif

--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -1,5 +1,3 @@
-//  operations.cpp  --------------------------------------------------------------------//
-
 //  Copyright 2002-2009, 2014 Beman Dawes
 //  Copyright 2001 Dietmar Kuehl
 //  Copyright 2018-2024 Andrey Semashev
@@ -3184,7 +3182,7 @@ bool copy_file(path const& from, path const& to, unsigned int options, error_cod
 #if !defined(BOOST_FILESYSTEM_USE_WASI)
     // If we created a new file with an explicitly added S_IWUSR permission,
     // we may need to update its mode bits to match the source file.
-    if (to_mode != from_mode)
+    if (BOOST_UNLIKELY(::fchmod(outfile.fd, from_mode) != 0) && (options & static_cast<unsigned int>(copy_options::skip_fchmod_failure)) == 0u )
     {
         if (BOOST_UNLIKELY(::fchmod(outfile.fd, from_mode) != 0))
             goto fail_errno;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -108,7 +108,7 @@ run issues/70-71-copy.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 run issues/99_canonical_with_junction_point.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 run issues/reparse_tag_file_placeholder.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
-run issues/179_test.cpp : : : <link>shared <define>BOOST_FILESYSTEM_VERSION=4 ;
+run issues/179 : : : <link>shared <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 if [ os.environ BOOST_FILESYSTEM_TEST_WITH_EXAMPLES ]
 {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -108,6 +108,7 @@ run issues/70-71-copy.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 run issues/99_canonical_with_junction_point.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 run issues/reparse_tag_file_placeholder.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
+run issues/179_test.cpp : : : <link>shared <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 if [ os.environ BOOST_FILESYSTEM_TEST_WITH_EXAMPLES ]
 {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -108,7 +108,7 @@ run issues/70-71-copy.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 run issues/99_canonical_with_junction_point.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
 run issues/reparse_tag_file_placeholder.cpp : : : <define>BOOST_FILESYSTEM_VERSION=4 ;
-run issues/179 : : : <link>shared <define>BOOST_FILESYSTEM_VERSION=4 ;
+run issues/179.cpp : : : <link>shared <define>BOOST_FILESYSTEM_VERSION=4 ;
 
 if [ os.environ BOOST_FILESYSTEM_TEST_WITH_EXAMPLES ]
 {

--- a/test/issues/179.cpp
+++ b/test/issues/179.cpp
@@ -1,9 +1,18 @@
 #include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/filesystem/fstream.hpp> 
+#include <boost/system/system_category.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 #include <sys/types.h> // for mode_t type
+#include <sys/stat.h>
 #include <fstream>     // for std::ofstream
 #include <iostream>    // for std::cout
 
 namespace fs = boost::filesystem;
+using boost::system::error_code;
+using boost::system::system_category;
 
 extern "C" int fchmod(int fd, mode_t mode) {
     // Return -1 to indicate failure
@@ -19,6 +28,16 @@ void create_file(const fs::path& ph, const std::string& contents = std::string()
         f << contents;
 }
 
+void verify_file(const fs::path& ph, const std::string& expected)
+{
+    std::ifstream f(BOOST_FILESYSTEM_C_STR(ph));
+    if (!f)
+        throw fs::filesystem_error("operations_test verify_file", ph, error_code(errno, system_category()));
+    std::string contents;
+    f >> contents;
+    if (contents != expected)
+        throw fs::filesystem_error("operations_test verify_file contents \"" + contents + "\" != \"" + expected + "\"", ph, error_code());
+}
 
 int cpp_main(int argc, char* argv[])
 {

--- a/test/issues/179.cpp
+++ b/test/issues/179.cpp
@@ -1,6 +1,7 @@
 #include <boost/filesystem.hpp>
 #include <sys/types.h> // for mode_t type
-#include <unistd.h> // for fchmod prototype
+#include <fstream>     // for std::ofstream
+#include <iostream>    // for std::cout
 
 namespace fs = boost::filesystem;
 
@@ -21,8 +22,8 @@ void create_file(const fs::path& ph, const std::string& contents = std::string()
 
 int cpp_main(int argc, char* argv[])
 {
-    file_copied = false;
-    copy_ex_ok = true;
+    bool file_copied = false;
+    bool copy_ex_ok = true;
     create_file("f1", "content"); // Ensure the source file exists with some content
 
     try
@@ -39,7 +40,7 @@ int cpp_main(int argc, char* argv[])
     BOOST_TEST(copy_ex_ok);
     BOOST_TEST(file_copied);
     BOOST_TEST(fs::exists("f2")); // The file should still exist despite the fchmod failure
-    verify_file(."f2", "content");
+    verify_file("f2", "content");
 
     fs::remove("f1");
     fs::remove("f2");

--- a/test/issues/179.cpp
+++ b/test/issues/179.cpp
@@ -1,0 +1,47 @@
+#include <boost/filesystem.hpp>
+#include <sys/types.h> // for mode_t type
+#include <unistd.h> // for fchmod prototype
+
+namespace fs = boost::filesystem;
+
+extern "C" int fchmod(int fd, mode_t mode) {
+    // Return -1 to indicate failure
+    return -1;
+}
+
+void create_file(const fs::path& ph, const std::string& contents = std::string())
+{
+    std::ofstream f(BOOST_FILESYSTEM_C_STR(ph));
+    if (!f.is_open())
+        throw fs::filesystem_error("operations_test create_file", ph, error_code(errno, system_category()));
+    if (!contents.empty())
+        f << contents;
+}
+
+
+int cpp_main(int argc, char* argv[])
+{
+    file_copied = false;
+    copy_ex_ok = true;
+    create_file("f1", "content"); // Ensure the source file exists with some content
+
+    try
+    {
+        // Attempt to use mocked fcmhod implementation which always errors out.
+        file_copied = fs::copy_file("f1", "f2", fs::copy_options::overwrite_existing);
+    }
+    catch (const fs::filesystem_error&)
+    {
+        // If a filesystem_error is thrown, the option did not work as expected
+        copy_ex_ok = false;
+    }
+
+    BOOST_TEST(copy_ex_ok);
+    BOOST_TEST(file_copied);
+    BOOST_TEST(fs::exists("f2")); // The file should still exist despite the fchmod failure
+    verify_file(."f2", "content");
+
+    fs::remove("f1");
+    fs::remove("f2");
+    return 0;
+}

--- a/test/issues/179.cpp
+++ b/test/issues/179.cpp
@@ -13,6 +13,7 @@
 namespace fs = boost::filesystem;
 using boost::system::error_code;
 using boost::system::system_category;
+typedef unsigned short mode_t;
 
 extern "C" int fchmod(int fd, mode_t mode) {
     // Return -1 to indicate failure


### PR DESCRIPTION
Added a new flag 'skip_fchmod_failure ' in copy_options to ignore errors from fchmod. This flag when used will suppress the errors arising from 'fchmod' 
A test is also added, which mocks a fchmod failure to test whether the fchmod failure is suppressed when the 'skip_fchmod_failure' flag is used . 
