### PR TITLE
Avoid unused constant error/warning

### DIFF
--- a/src/operations.cpp
+++ b/src/operations.cpp
@@ -278,8 +278,6 @@ BOOST_CONSTEXPR_OR_CONST std::size_t small_path_size = 1024u;
 // - GNU/Hurd: no hard limit
 BOOST_CONSTEXPR_OR_CONST std::size_t absolute_path_max = 32u * 1024u;
 
-#endif // defined(BOOST_POSIX_API)
-
 // Maximum number of resolved symlinks before we register a loop
 BOOST_CONSTEXPR_OR_CONST unsigned int symloop_max =
 #if defined(SYMLOOP_MAX)
@@ -288,6 +286,8 @@ BOOST_CONSTEXPR_OR_CONST unsigned int symloop_max =
     40
 #endif
 ;
+
+#endif // defined(BOOST_POSIX_API)
 
 //  general helpers  -----------------------------------------------------------------//
 


### PR DESCRIPTION
symloop_max is only used for POSIX_API and otherwise Clang warns about it:

> unused variable 'symloop_max' [-Werror,-Wunused-const-variable]
> BOOST_CONSTEXPR_OR_CONST unsigned int symloop_max =

Move it into the define-check block