### PR TITLE
Remove remnants of copy_directory() from reference.html

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -119,7 +119,6 @@
     <code>&nbsp;&nbsp;&nbsp;&nbsp; <a href="#absolute">absolute</a><br/>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#canonical">canonical</a><br/>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#copy">copy</a><br/>
-&nbsp;&nbsp;&nbsp;&nbsp; <a href="#copy_directory">copy_directory</a><br/>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#copy_file">copy_file</a><br/>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#copy_symlink">copy_symlink</a><br/>
 &nbsp;&nbsp;&nbsp;&nbsp; <a href="#create_directories">create_directories</a><br/>


### PR DESCRIPTION
The reference of the documentation still lists the function `copy_directory`.
However, this function was deprecated with 1.74.0 and removed with 1.85.0. Its documentation was removed from the document as well, only the (dead) link I'm proposing to remove survived.